### PR TITLE
fix: escape multiline commit message in monorepo notify workflow

### DIFF
--- a/.github/workflows/notify-monorepo-workflow-content.yml
+++ b/.github/workflows/notify-monorepo-workflow-content.yml
@@ -17,12 +17,8 @@ jobs:
     - name: Prepare commit message
       id: prepare
       run: |
-        # Escapar caracteres especiales en el mensaje del commit
-        COMMIT_MSG="${{ github.event.head_commit.message }}"
-        # Reemplazar saltos de línea con \n y escapar comillas
-        ESCAPED_MSG=$(echo "$COMMIT_MSG" | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g')
-        echo "commit_message=$ESCAPED_MSG" >> $GITHUB_OUTPUT
-        
+        echo "commit_message=${{ toJSON(github.event.head_commit.message) }}" >> $GITHUB_OUTPUT
+
     - name: Notify monorepo repository
       uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0  # v3.0.0
       with:
@@ -34,7 +30,7 @@ jobs:
             "repository": "TFG_UNIR-backend",
             "ref": "${{ github.ref }}",
             "sha": "${{ github.sha }}",
-            "commit_message": "${{ steps.prepare.outputs.commit_message }}",
+            "commit_message": ${{ steps.prepare.outputs.commit_message }},
             "pusher": "${{ github.event.pusher.name }}",
             "timestamp": "${{ github.event.head_commit.timestamp }}"
           }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md - TFG UNIR Backend
 
 ## Stack
-- Java 21 + Spring Boot 3.5.14 + Maven (`./mvnw`)
+- Java 21 + Spring Boot 3.5.15 + Maven (`./mvnw`)
 - H2 (tests), PostgreSQL (prod)
 - JWT auth, CSRF disabled, stateless API
 - Logging: `java.util.logging.Logger` (not SLF4J)
@@ -49,11 +49,11 @@
 - SonarQube: https://sonarcloud.io/project/overview?id=isidromerayo_TFG_UNIR-backend
 
 ## Known Vulnerabilities
-Current scan shows Apache Tomcat CVEs (CVE-2026-34483, 34486, 34487, 34500) in `tomcat-embed-core-10.1.53`.
-Check `target/dependency-check-report.html` after running OWASP scan.
+No Tomcat CVEs — Spring Boot 3.5.15 ships `tomcat-embed-core-10.1.55` (all previous CVEs fixed).
+Run OWASP scan periodically: `./mvnw -Pdependency-check verify -Dnvd.api.key=$NVD_API_KEY`
 
 ## Skills
 `springboot-tdd`, `springboot-security`, `springboot-patterns`, `xp-tdd-practices`, `testing-standards`, `action-tdd`, `task-validate`, `task-testing-review`
 
 ---
-**Updated:** 2026-05-01
+**Updated:** 2026-06-25

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md - TFG UNIR Backend
 
 ## Stack
-- Java 21 + Spring Boot 3.5.14 + Maven (`./mvnw`)
+- Java 21 + Spring Boot 3.5.15 + Maven (`./mvnw`)
 - H2 (tests), PostgreSQL (prod)
 - JWT auth, CSRF disabled, stateless API
 - Logging: `java.util.logging.Logger` (not SLF4J)
@@ -49,11 +49,11 @@
 - SonarQube: https://sonarcloud.io/project/overview?id=isidromerayo_TFG_UNIR-backend
 
 ## Known Vulnerabilities
-Current scan shows Apache Tomcat CVEs (CVE-2026-34483, 34486, 34487, 34500) in `tomcat-embed-core-10.1.53`.
-Check `target/dependency-check-report.html` after running OWASP scan.
+No Tomcat CVEs — Spring Boot 3.5.15 ships `tomcat-embed-core-10.1.55` (all previous CVEs fixed).
+Run OWASP scan periodically: `./mvnw -Pdependency-check verify -Dnvd.api.key=$NVD_API_KEY`
 
 ## Skills
 `springboot-tdd`, `springboot-security`, `springboot-patterns`, `xp-tdd-practices`, `testing-standards`, `action-tdd`, `task-validate`, `task-testing-review`
 
 ---
-**Updated:** 2026-05-01
+**Updated:** 2026-06-24

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md - TFG UNIR Backend
 
 ## Stack
-- Java 21 + Spring Boot 3.5.15 + Maven (`./mvnw`)
+- Java 21 + Spring Boot 3.5.16 + Maven (`./mvnw`)
 - H2 (tests), PostgreSQL (prod)
 - JWT auth, CSRF disabled, stateless API
 - Logging: `java.util.logging.Logger` (not SLF4J)
@@ -24,8 +24,8 @@
 # Full verification with coverage
 ./mvnw clean verify -Pintegration-tests
 
-# Vulnerability scan (requires NVD_API_KEY)
-./mvnw -Pdependency-check verify -Dnvd.api.key=$NVD_API_KEY
+# Vulnerability scan (requires NVD_API_KEY) - skips tests, only runs OWASP check
+./mvnw -Pdependency-check dependency-check:check -Dnvd.api.key=$NVD_API_KEY
 ```
 
 ## Non-Negotiable Rules
@@ -49,11 +49,16 @@
 - SonarQube: https://sonarcloud.io/project/overview?id=isidromerayo_TFG_UNIR-backend
 
 ## Known Vulnerabilities
-No Tomcat CVEs — Spring Boot 3.5.15 ships `tomcat-embed-core-10.1.55` (all previous CVEs fixed).
-Run OWASP scan periodically: `./mvnw -Pdependency-check verify -Dnvd.api.key=$NVD_API_KEY`
+No Tomcat CVEs — Spring Boot 3.5.16 ships `tomcat-embed-core-10.1.55` (all previous CVEs fixed).
+Run OWASP scan periodically: `./mvnw -Pdependency-check dependency-check:check -Dnvd.api.key=$NVD_API_KEY`
+
+### Dependency-Check False Positives
+These CVEs are flagged by the CPE matcher but do **not** affect the project:
+- **CVE-2026-34479, CVE-2026-34477** on `log4j-api-2.24.3.jar` — both require `log4j-core` (not present). The project only has `log4j-api` (interfaces) and `log4j-to-slf4j` (routing bridge). These CVEs target the Log4j 1→2 bridge XML layout and SocketAppender SSL — none of which are used.
+- **All CVEs on `swagger-ui-5.32.2.jar` (DOMPurify@3.3.2)** — Swagger UI is a dev-only client-side tool served via `springdoc-openapi`. DOMPurify runs in the browser, sanitizing user-supplied HTML before rendering. The backend never passes user HTML through DOMPurify, so these CVEs are not exploitable server-side. No remediation required.
 
 ## Skills
 `springboot-tdd`, `springboot-security`, `springboot-patterns`, `xp-tdd-practices`, `testing-standards`, `action-tdd`, `task-validate`, `task-testing-review`
 
 ---
-**Updated:** 2026-06-25
+**Updated:** 2026-06-28

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - H2 (tests), PostgreSQL (prod)
 - JWT auth, CSRF disabled, stateless API
 - Logging: `java.util.logging.Logger` (not SLF4J)
+- Security plugins: SpotBugs 4.10.2 + FindSecBugs 1.14.0 + fb-contrib 7.7.4
 
 ## Package Layout
 `src/main/java/eu/estilolibre/tfgunir/backend/`
@@ -51,6 +52,11 @@
 ## Known Vulnerabilities
 No Tomcat CVEs — Spring Boot 3.5.16 ships `tomcat-embed-core-10.1.55` (all previous CVEs fixed).
 Run OWASP scan periodically: `./mvnw -Pdependency-check dependency-check:check -Dnvd.api.key=$NVD_API_KEY`
+
+### Dependency-Check False Positives
+These CVEs are flagged by the CPE matcher but do **not** affect the project:
+- **CVE-2026-34479, CVE-2026-34477** on `log4j-api-2.24.3.jar` — both require `log4j-core` (not present). The project only has `log4j-api` (interfaces) and `log4j-to-slf4j` (routing bridge). These CVEs target the Log4j 1→2 bridge XML layout and SocketAppender SSL — none of which are used.
+- **All CVEs on `swagger-ui-5.32.2.jar` (DOMPurify@3.3.2)** — Swagger UI is a dev-only client-side tool served via `springdoc-openapi`. DOMPurify runs in the browser, sanitizing user-supplied HTML before rendering. The backend never passes user HTML through DOMPurify, so these CVEs are not exploitable server-side. No remediation required.
 
 ### Dependency-Check False Positives
 These CVEs are flagged by the CPE matcher but do **not** affect the project:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,11 +58,6 @@ These CVEs are flagged by the CPE matcher but do **not** affect the project:
 - **CVE-2026-34479, CVE-2026-34477** on `log4j-api-2.24.3.jar` — both require `log4j-core` (not present). The project only has `log4j-api` (interfaces) and `log4j-to-slf4j` (routing bridge). These CVEs target the Log4j 1→2 bridge XML layout and SocketAppender SSL — none of which are used.
 - **All CVEs on `swagger-ui-5.32.2.jar` (DOMPurify@3.3.2)** — Swagger UI is a dev-only client-side tool served via `springdoc-openapi`. DOMPurify runs in the browser, sanitizing user-supplied HTML before rendering. The backend never passes user HTML through DOMPurify, so these CVEs are not exploitable server-side. No remediation required.
 
-### Dependency-Check False Positives
-These CVEs are flagged by the CPE matcher but do **not** affect the project:
-- **CVE-2026-34479, CVE-2026-34477** on `log4j-api-2.24.3.jar` — both require `log4j-core` (not present). The project only has `log4j-api` (interfaces) and `log4j-to-slf4j` (routing bridge). These CVEs target the Log4j 1→2 bridge XML layout and SocketAppender SSL — none of which are used.
-- **All CVEs on `swagger-ui-5.32.2.jar` (DOMPurify@3.3.2)** — Swagger UI is a dev-only client-side tool served via `springdoc-openapi`. DOMPurify runs in the browser, sanitizing user-supplied HTML before rendering. The backend never passes user HTML through DOMPurify, so these CVEs are not exploitable server-side. No remediation required.
-
 ## Skills
 `springboot-tdd`, `springboot-security`, `springboot-patterns`, `xp-tdd-practices`, `testing-standards`, `action-tdd`, `task-validate`, `task-testing-review`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md - TFG UNIR Backend
 
 ## Stack
-- Java 21 + Spring Boot 3.5.15 + Maven (`./mvnw`)
+- Java 21 + Spring Boot 3.5.14 + Maven (`./mvnw`)
 - H2 (tests), PostgreSQL (prod)
 - JWT auth, CSRF disabled, stateless API
 - Logging: `java.util.logging.Logger` (not SLF4J)
@@ -49,11 +49,11 @@
 - SonarQube: https://sonarcloud.io/project/overview?id=isidromerayo_TFG_UNIR-backend
 
 ## Known Vulnerabilities
-No Tomcat CVEs — Spring Boot 3.5.15 ships `tomcat-embed-core-10.1.55` (all previous CVEs fixed).
-Run OWASP scan periodically: `./mvnw -Pdependency-check verify -Dnvd.api.key=$NVD_API_KEY`
+Current scan shows Apache Tomcat CVEs (CVE-2026-34483, 34486, 34487, 34500) in `tomcat-embed-core-10.1.53`.
+Check `target/dependency-check-report.html` after running OWASP scan.
 
 ## Skills
 `springboot-tdd`, `springboot-security`, `springboot-patterns`, `xp-tdd-practices`, `testing-standards`, `action-tdd`, `task-validate`, `task-testing-review`
 
 ---
-**Updated:** 2026-06-24
+**Updated:** 2026-05-01

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 ### 📄 Licencia
 [![License](https://img.shields.io/github/license/isidromerayo/TFG_UNIR-backend?color=blue&style=flat-square)](LICENSE)
 [![Java](https://img.shields.io/badge/Java-21-007396?logo=java&logoColor=white)](https://www.oracle.com/java/technologies/)
-[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.15-6DB33F?logo=spring&logoColor=white)](https://spring.io/projects/spring-boot)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.16-6DB33F?logo=spring&logoColor=white)](https://spring.io/projects/spring-boot)
 
 </div>
 
@@ -71,15 +71,15 @@ Este repositorio versiona *skills* (guías y patrones en Markdown) para que los 
 ### 🛠️ Stack tecnológico
 
 - **Java 21**
-- **Spring Boot 3.5.15**
-- **Spring Framework 6.2.15**
-- **Hibernate 6.6.41**
+- **Spring Boot 3.5.16**
+- **Spring Framework 6.2.19**
+- **Hibernate 6.6.53.Final**
 - **Spring Data JPA** - Persistencia
-- **Spring Security 6.5.7** - Autenticación y autorización
+- **Spring Security 6.5.11** - Autenticación y autorización
 - **PostgreSQL 15+** - Base de datos producción
 - **H2** - Base de datos testing
 - **JWT** - Tokens de autenticación
-- **Swagger/OpenAPI 2.8.5** - Documentación API
+- **Swagger/OpenAPI 2.8.17** - Documentación API
 - **Lombok** - Reducción de boilerplate
 - **JaCoCo** - Cobertura de código
 - **SpotBugs** - Análisis estático
@@ -1056,7 +1056,7 @@ Este comando:
 | **Security Rating** | A | A | ✅ |
 | **Quality Gate** | Passed | Passed | ✅ |
 
-**Última actualización**: 2026-02-07 (Migración a PostgreSQL)
+**Última actualización**: 2026-06-29 (Release v0.6.2)
 
 Ver más detalles en [SonarCloud](https://sonarcloud.io/project/overview?id=isidromerayo_TFG_UNIR-backend)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 ### 📄 Licencia
 [![License](https://img.shields.io/github/license/isidromerayo/TFG_UNIR-backend?color=blue&style=flat-square)](LICENSE)
 [![Java](https://img.shields.io/badge/Java-21-007396?logo=java&logoColor=white)](https://www.oracle.com/java/technologies/)
-[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.10-6DB33F?logo=spring&logoColor=white)](https://spring.io/projects/spring-boot)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.15-6DB33F?logo=spring&logoColor=white)](https://spring.io/projects/spring-boot)
 
 </div>
 
@@ -71,7 +71,7 @@ Este repositorio versiona *skills* (guías y patrones en Markdown) para que los 
 ### 🛠️ Stack tecnológico
 
 - **Java 21**
-- **Spring Boot 3.5.10**
+- **Spring Boot 3.5.15**
 - **Spring Framework 6.2.15**
 - **Hibernate 6.6.41**
 - **Spring Data JPA** - Persistencia

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentación del Proyecto TFG UNIR Backend
 
-**Última actualización**: 2026-05-01
+**Última actualización**: 2026-06-25
 
 ---
 
@@ -126,7 +126,7 @@ open target/site/jacoco-it/index.html   # Solo integración
 | **Cobertura de código** | 100%* | ≥ 80% | ✅ |
 | **Tests unitarios** | 11 | - | ✅ |
 | **Tests integración** | 4 | - | ✅ |
-| **Spring Boot** | 3.5.11 | Latest | ✅ |
+| **Spring Boot** | 3.5.15 | Latest | ✅ |
 | **Java** | 21 | LTS | ✅ |
 | **Quality Gate** | Passed | Passed | ✅ |
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.14</version>
+		<version>3.5.15</version>
 		<relativePath />
 		<!-- lookup parent from repository -->
 	</parent>
@@ -33,6 +33,8 @@
 		<git-commit-id-plugin.version>9.0.2</git-commit-id-plugin.version>
 		<sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
 		<dependency-check-maven.version>12.1.9</dependency-check-maven.version>
+		<dependency-check.skip>false</dependency-check.skip>
+		<dependency-check.data.directory>${user.home}/.dependency-check/data</dependency-check.data.directory>
 		<spotbugs-maven-plugin.version>4.11.0</spotbugs-maven-plugin.version>
 		<jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
 
@@ -382,6 +384,9 @@
 						</executions>
 						<configuration>
 							<nvdApiKey>${env.NVD_API_KEY}</nvdApiKey>
+							<dataDirectory>${dependency-check.data.directory}</dataDirectory>
+							<format>HTML</format>
+							<failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
 						</configuration>
 					</plugin>
 				</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.14</version>
+		<version>3.5.15</version>
 		<relativePath />
 		<!-- lookup parent from repository -->
 	</parent>

--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
 		<maven-failsafe-plugin.version>3.5.4</maven-failsafe-plugin.version>
 		<git-commit-id-plugin.version>9.0.2</git-commit-id-plugin.version>
 		<sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
-		<dependency-check-maven.version>12.1.9</dependency-check-maven.version>
-		<spotbugs-maven-plugin.version>4.11.0</spotbugs-maven-plugin.version>
+		<dependency-check-maven.version>12.2.2</dependency-check-maven.version>
+		<spotbugs-maven-plugin.version>4.10.2.0</spotbugs-maven-plugin.version>
 		<jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
 
 		<!-- SonarQube Configuration -->
@@ -308,13 +308,13 @@
 			<plugin>
 				<groupId>com.github.spotbugs</groupId>
 				<artifactId>spotbugs-maven-plugin</artifactId>
-				<version>4.9.8.3</version>
+				<version>${spotbugs-maven-plugin.version}</version>
 				<dependencies>
 					<!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
 					<dependency>
 						<groupId>com.github.spotbugs</groupId>
 						<artifactId>spotbugs</artifactId>
-						<version>4.9.8</version>
+						<version>4.10.2</version>
 					</dependency>
 				</dependencies>
 				<configuration>
@@ -328,7 +328,7 @@
 						<plugin>
 							<groupId>com.mebigfatguy.fb-contrib</groupId>
 							<artifactId>fb-contrib</artifactId>
-							<version>7.7.2</version>
+							<version>7.7.4</version>
 						</plugin>
 					</plugins>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.15</version>
+		<version>3.5.14</version>
 		<relativePath />
 		<!-- lookup parent from repository -->
 	</parent>
@@ -33,8 +33,6 @@
 		<git-commit-id-plugin.version>9.0.2</git-commit-id-plugin.version>
 		<sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
 		<dependency-check-maven.version>12.1.9</dependency-check-maven.version>
-		<dependency-check.skip>false</dependency-check.skip>
-		<dependency-check.data.directory>${user.home}/.dependency-check/data</dependency-check.data.directory>
 		<spotbugs-maven-plugin.version>4.11.0</spotbugs-maven-plugin.version>
 		<jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
 
@@ -384,9 +382,6 @@
 						</executions>
 						<configuration>
 							<nvdApiKey>${env.NVD_API_KEY}</nvdApiKey>
-							<dataDirectory>${dependency-check.data.directory}</dataDirectory>
-							<format>HTML</format>
-							<failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
 						</configuration>
 					</plugin>
 				</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.15</version>
+		<version>3.5.16</version>
 		<relativePath />
 		<!-- lookup parent from repository -->
 	</parent>
@@ -25,8 +25,8 @@
 		<jjwt.version>0.13.0</jjwt.version>
 		<commons-lang3.version>3.20.0</commons-lang3.version>
 		<jackson.version>2.21.1</jackson.version>
-		<springdoc-openapi-starter-webmvc-ui.version>2.8.4</springdoc-openapi-starter-webmvc-ui.version>
-		<springdoc-openapi-starter-common.version>2.8.4</springdoc-openapi-starter-common.version>
+		<springdoc-openapi-starter-webmvc-ui.version>2.8.17</springdoc-openapi-starter-webmvc-ui.version>
+		<springdoc-openapi-starter-common.version>2.8.17</springdoc-openapi-starter-common.version>
 
 		<!-- Plugins Versions -->
 		<maven-failsafe-plugin.version>3.5.4</maven-failsafe-plugin.version>
@@ -131,6 +131,7 @@
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>${springdoc-openapi-starter-webmvc-ui.version}</version>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-common</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>eu.estilolibre.tfgunir</groupId>
 	<artifactId>backend</artifactId>
-	<version>0.6.2-SNAPSHOT</version>
+	<version>0.6.2</version>
 	<name>backend</name>
 	<description>Backend para TFG en UNIR usando Spring Boot</description>
 	<properties>
@@ -58,7 +58,7 @@
 	<scm>
 		<connection>scm:git:https://github.com/isidromerayo/TFG_UNIR-backend.git</connection>
 		<url>https://github.com/isidromerayo/TFG_UNIR-backend</url>
-	  <tag>v0.5.2</tag>
+	  <tag>v0.6.2</tag>
   </scm>
 	<distributionManagement>
 		<repository>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>eu.estilolibre.tfgunir</groupId>
 	<artifactId>backend</artifactId>
-	<version>0.6.2</version>
+	<version>0.6.3-SNAPSHOT</version>
 	<name>backend</name>
 	<description>Backend para TFG en UNIR usando Spring Boot</description>
 	<properties>
@@ -58,7 +58,7 @@
 	<scm>
 		<connection>scm:git:https://github.com/isidromerayo/TFG_UNIR-backend.git</connection>
 		<url>https://github.com/isidromerayo/TFG_UNIR-backend</url>
-	  <tag>v0.6.2</tag>
+	  <tag>v0.5.2</tag>
   </scm>
 	<distributionManagement>
 		<repository>

--- a/src/test/java/eu/estilolibre/tfgunir/backend/OpenApiDocumentationIT.java
+++ b/src/test/java/eu/estilolibre/tfgunir/backend/OpenApiDocumentationIT.java
@@ -1,0 +1,54 @@
+package eu.estilolibre.tfgunir.backend;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class OpenApiDocumentationIT {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void apiDocsEndpointReturns200() {
+        ResponseEntity<String> response = restTemplate.getForEntity("/v3/api-docs", String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void apiDocsResponseContainsOpenApiStructure() {
+        ResponseEntity<String> response = restTemplate.getForEntity("/v3/api-docs", String.class);
+
+        assertThat(response.getBody())
+            .contains("\"openapi\"")
+            .contains("\"info\"")
+            .contains("\"paths\"");
+    }
+
+    @Test
+    void swaggerUiReturnsOk() {
+        ResponseEntity<String> response = restTemplate.getForEntity("/swagger-ui.html", String.class);
+
+        assertThat(response.getStatusCode())
+            .as("Body: " + response.getBody())
+            .isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void swaggerUiResourcesAccessible() {
+        ResponseEntity<String> response = restTemplate.getForEntity("/swagger-ui/index.html", String.class);
+
+        assertThat(response.getStatusCode())
+            .as("Body: " + response.getBody())
+            .isEqualTo(HttpStatus.OK);
+    }
+}


### PR DESCRIPTION
## Fix

El workflow de notificación al monorepo fallaba al recibir un mensaje de commit multilínea con paréntesis (como "(v0.6.2)"), porque se inyectaba directamente en el script sin escape.

### Cambios
- `notify-monorepo-workflow-content.yml`: usar `toJSON()` para escapar correctamente el mensaje del commit (maneja saltos de línea, paréntesis, comillas, etc.)
- El `client-payload` JSON ahora usa directamente el valor de `toJSON` (ya incluye comillas), evitando doble escape.

**Nota**: Este archivo es una plantilla. La copia real en el monorepo (`isidromerayo/TFG_UNIR-monorepo/.github/workflows/notify-monorepo.yml`) también debe actualizarse con el mismo contenido.