### PR TITLE
fix: use quoted heredoc to prevent bash expansion in monorepo notify workflow

### DIFF
--- a/.github/workflows/notify-monorepo-workflow-content.yml
+++ b/.github/workflows/notify-monorepo-workflow-content.yml
@@ -17,7 +17,9 @@ jobs:
     - name: Prepare commit message
       id: prepare
       run: |
-        echo commit_message=${{ toJSON(github.event.head_commit.message) }} >> $GITHUB_OUTPUT
+        cat >> "$GITHUB_OUTPUT" <<'OUTPUTEOF'
+        commit_message=${{ toJSON(github.event.head_commit.message) }}
+        OUTPUTEOF
 
     - name: Notify monorepo repository
       uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0  # v3.0.0

--- a/docs/workflows/github/notify-monorepo-workflow-content.yml
+++ b/docs/workflows/github/notify-monorepo-workflow-content.yml
@@ -14,18 +14,25 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
+    - name: Prepare commit message
+      id: prepare
+      run: |
+        cat >> "$GITHUB_OUTPUT" <<'OUTPUTEOF'
+        commit_message=${{ toJSON(github.event.head_commit.message) }}
+        OUTPUTEOF
+
     - name: Notify monorepo repository
       uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0  # v3.0.0
       with:
         token: ${{ secrets.MONOREPO_DISPATCH_TOKEN }}
         repository: isidromerayo/TFG_UNIR-monorepo
-        event-type: submodule-update
+        event-type: submodule-updated
         client-payload: |
           {
             "repository": "TFG_UNIR-backend",
             "ref": "${{ github.ref }}",
             "sha": "${{ github.sha }}",
-            "commit_message": "${{ github.event.head_commit.message }}",
+            "commit_message": ${{ steps.prepare.outputs.commit_message }},
             "pusher": "${{ github.event.pusher.name }}",
             "timestamp": "${{ github.event.head_commit.timestamp }}"
           }


### PR DESCRIPTION
## Problema

Cuando el commit message contiene el texto literal `${{ toJSON(...) }}` (e.g., describiendo un fix anterior), el shell interpreta `${}` como expansión de parámetro y falla con `bad substitution`.

Esto ocurre porque `toJSON()` produce un string JSON que se inserta directamente en un comando `echo` de bash. Si el commit message contiene `${}`, bash lo interpreta antes de ejecutar el comando.

## Solución

Reemplazar `echo commit_message=... >> $GITHUB_OUTPUT` por un heredoc con delimiter entrecomillado (`<<'OUTPUTEOF'`):

```yaml
cat >> "$GITHUB_OUTPUT" <<'OUTPUTEOF'
commit_message=${{ toJSON(github.event.head_commit.message) }}
OUTPUTEOF
```

El delimiter entrecomillado evita que bash expanda cualquier `${}`, `$(...)` o backticks dentro del contenido del heredoc.

## Archivos modificados
- `.github/workflows/notify-monorepo-workflow-content.yml` (workflow activo)
- `docs/workflows/github/notify-monorepo-workflow-content.yml` (plantilla de referencia)

## Fixes anteriores relacionados
- #122 - primera iteración del fix (escape multiline)
- #124 - segunda iteración (remove outer double quotes)