### PR TITLE
docs: update documentation for Docker release flow and PostgreSQL migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,10 +59,29 @@ git checkout vX.Y.Z && ./mvnw clean package -DskipTests
 ./scripts/publish-images.sh --dry-run
 
 # 5. (Opcional) Publicar BD si hay cambios estructurales
-./scripts/publish-db-image.sh 1.1
+POSTGRES_PASSWORD=<password> ./scripts/publish-db-image.sh 1.1
 
 # 6. Volver a main y subir tags
 git checkout main && git push origin main --tags
+```
+
+## Documentation Workflow
+
+When making changes, update the affected docs **before commit**:
+
+| Change type | Files to update |
+|-------------|-----------------|
+| New/modified REST endpoint | `README.md` (API section), Swagger annotations |
+| New script in `scripts/` | `scripts/README.md` |
+| Docker/Dockerfile change | `docs/docker/DOCKER_IMAGES_GUIDE.md`, `docker-compose.yml` |
+| Security change | `docs/security/` relevant file, `AGENTS.md` Known Vulnerabilities |
+| Dependency upgrade | `pom.xml` versions, `AGENTS.md` Stack section |
+| New feature/bugfix | `README.md` if user-facing |
+
+**Quick check before commit:**
+```bash
+# Verify docs mention new script/feature
+grep -r "new-feature-name" docs/ scripts/README.md README.md
 ```
 
 ## Tooling

--- a/README.md
+++ b/README.md
@@ -344,88 +344,31 @@ deploy:
 Para usar una instancia limpia de PostgreSQL:
 
 ```bash
-docker run --name postgres-tfg -e POSTGRES_PASSWORD=mypass -e POSTGRES_DB=tfg_unir -e POSTGRES_USER=user_tfg -p 5432:5432 -d postgres:latest
+docker run --name postgres-tfg -e POSTGRES_PASSWORD=mypass -e POSTGRES_DB=tfg_unir -e POSTGRES_USER=user_tfg -p 5432:5432 -d postgres:17
 ```
 
-Esta imagen incluye:
-- Base de datos `tfg_unir` creada
-- Usuario `user_tfg` con contraseña `tfg_un1r_PWD`
-- Datos de prueba precargados
-
-##### Construir imagen personalizada de PostgreSQL (Opcional)
-
-El proyecto incluye un `Dockerfile-db-postgresql` para crear una imagen personalizada si fuera necesario:
-
-**1. Verificar prerequisitos**
-
-Asegúrate de que existen los scripts SQL en `../recursos/db/postgresql/`:
-- `01-create.sql`
-- `02-create.sql`
-- `03-create.sql`
-
-**2. Construir la imagen**
+##### Construir imagen personalizada de PostgreSQL
 
 ```bash
 cd backend
 
-# Construir imagen personalizada
-docker build -f Dockerfile-db-postgresql -t isidromerayo/postgres-tfg:latest .
+# Construir imagen (requiere POSTGRES_PASSWORD)
+POSTGRES_PASSWORD=mi_password docker build -f Dockerfile-db-postgresql \
+    --build-arg POSTGRES_PASSWORD=mi_password \
+    -t isidromerayo/postgres-tfg:1.0 .
 ```
 
-**3. Probar la imagen localmente**
+##### Publicar imágenes en Docker Hub
 
 ```bash
-# Ejecutar contenedor
-docker run --name postgres-test -p 5432:5432 -d isidromerayo/postgres-tfg:latest
+# Backend (extrae versión del pom.xml, rechaza SNAPSHOT)
+./scripts/publish-images.sh
 
-# Verificar que funciona
-docker logs postgres-test
-
-# Conectar a la base de datos
-psql -h localhost -U user_tfg -d tfg_unir
+# PostgreSQL (requiere POSTGRES_PASSWORD)
+POSTGRES_PASSWORD=mi_password ./scripts/publish-db-image.sh 1.0
 ```
 
-**4. Publicar en Docker Hub**
-
-```bash
-# Login (si no lo has hecho)
-docker login
-
-# Push de la versión específica
-docker push isidromerayo/mariadb-tfg:0.0.4
-
-# Push del tag latest
-docker push isidromerayo/mariadb-tfg:latest
-```
-
-##### Configuración del Dockerfile-db
-
-El `Dockerfile-db` configura:
-
-```dockerfile
-FROM mariadb:latest
-
-ENV MARIADB_ROOT_PASSWORD=mypass
-ENV MYSQL_DATABASE=tfg_unir
-ENV MYSQL_USER=user_tfg
-ENV MYSQL_PASSWORD=tfg_un1r_PWD
-
-EXPOSE 3306
-```
-
-> **⚠️ Nota de seguridad**: Las credenciales están hardcodeadas para desarrollo. En producción, usa variables de entorno o secrets.
-
-##### Carga de datos inicial
-
-Cuando usas `docker-compose`, los scripts SQL se montan automáticamente:
-
-```yaml
-volumes:
-  - ../recursos/db/create.mariadb.sql:/docker-entrypoint-initdb.d/create.mariadb.sql
-  - ../recursos/db/dump.mariadb.sql:/docker-entrypoint-initdb.d/dump.mariadb.sql
-```
-
-MariaDB ejecuta automáticamente los scripts en `/docker-entrypoint-initdb.d/` al iniciar por primera vez.
+Ver guía completa: [docs/docker/DOCKER_IMAGES_GUIDE.md](docs/docker/DOCKER_IMAGES_GUIDE.md)
 
 #### BBDD: H2 para test
 
@@ -466,13 +409,14 @@ https://javatodev.com/docker-compose-for-spring-boot-with-mariadb/
 
 #### 🐳 docker compose
 
-Con docker compose se montará un contenedor con MariaDB (datos precargados) y otro con la aplicación de Spring Boot 3 con el API.
+Con docker compose se montará un contenedor con PostgreSQL (datos precargados) y otro con la aplicación de Spring Boot con el API.
 
 ##### Prerequisitos
 
-1. **Archivos SQL**: Deben existir en `../recursos/db/`:
-   - `create.mariadb.sql` - Script de creación de esquema
-   - `dump.mariadb.sql` - Datos iniciales
+1. **Archivos SQL**: Deben existir en `../recursos/db/postgresql/`:
+   - `01-create.sql` - Creación de esquema
+   - `02-create.sql` - Tablas
+   - `03-create.sql` - Datos iniciales
 
 2. **Configuración del backend**: El `application.properties` debe soportar variables de entorno:
    ```properties
@@ -523,103 +467,19 @@ Para detener las instancias de los contenedores `docker compose stop`.
 
 #### 📤 Publicar imágenes en Docker Hub
 
-Esta sección documenta el proceso completo para publicar imágenes del backend en Docker Hub.
-
-##### Flujo completo con Docker
-
-**1. Construir la imagen**
-
-Primero, asegúrate de tener el JAR actualizado:
+##### Usar scripts automatizados
 
 ```bash
-cd backend
-./mvnw clean install
+# Publicar backend (extrae versión del pom.xml)
+./scripts/publish-images.sh
+
+# Publicar PostgreSQL (requiere variable de entorno)
+POSTGRES_PASSWORD=mi_password ./scripts/publish-db-image.sh 1.0
 ```
 
-**2. Crear la imagen Docker**
+##### Flujo completo de release
 
-```bash
-# Construir con versión específica
-docker build -t isidromerayo/spring-backend-tfg:1.0.0 .
-
-# También crear tag 'latest' para la versión más reciente
-docker tag isidromerayo/spring-backend-tfg:1.0.0 isidromerayo/spring-backend-tfg:latest
-```
-
-**3. Login en Docker Hub**
-
-```bash
-docker login
-
-# Introducir credenciales cuando se soliciten
-# Username: isidromerayo
-# Password: [tu token de acceso]
-```
-
-> **💡 Tip**: Se recomienda usar un Personal Access Token en lugar de la contraseña. Créalo en: https://hub.docker.com/settings/security
-
-**4. Publicar la imagen**
-
-```bash
-# Push de la versión específica
-docker push isidromerayo/spring-backend-tfg:1.0.0
-
-# Push del tag latest
-docker push isidromerayo/spring-backend-tfg:latest
-```
-
-**5. Verificar la publicación**
-
-Visita: https://hub.docker.com/r/isidromerayo/spring-backend-tfg/tags
-
-##### Flujo completo con Podman
-
-**1. Construir la imagen**
-
-```bash
-cd backend
-./mvnw clean install
-```
-
-**2. Crear la imagen Podman**
-
-```bash
-# Construir con versión específica
-podman build -t isidromerayo/spring-backend-tfg:1.0.0 .
-
-# También crear tag 'latest'
-podman tag isidromerayo/spring-backend-tfg:1.0.0 isidromerayo/spring-backend-tfg:latest
-```
-
-**3. Login en Docker Hub**
-
-```bash
-podman login docker.io
-
-# Introducir credenciales cuando se soliciten
-# Username: isidromerayo
-# Password: [tu token de acceso]
-```
-
-**4. Publicar la imagen**
-
-```bash
-# Push de la versión específica
-podman push isidromerayo/spring-backend-tfg:1.0.0
-
-# Push del tag latest
-podman push isidromerayo/spring-backend-tfg:latest
-```
-
-**5. Verificar la publicación**
-
-```bash
-# Listar imágenes locales
-podman images | grep spring-backend-tfg
-
-# Verificar en Docker Hub
-# https://hub.docker.com/r/isidromerayo/spring-backend-tfg/tags
-```
+Ver [AGENTS.md - Release Flow](AGENTS.md) para el proceso completo.
 
 ##### Guía de versionado
 
@@ -632,56 +492,23 @@ Seguimos [Semantic Versioning](https://semver.org/):
 
 **Ejemplos:**
 ```bash
-# Primera versión estable
-docker build -t isidromerayo/spring-backend-tfg:1.0.0 .
+# El script detecta la versión del pom.xml automáticamente
+./scripts/publish-images.sh
 
-# Corrección de bug
-docker build -t isidromerayo/spring-backend-tfg:1.0.1 .
-
-# Nueva funcionalidad
-docker build -t isidromerayo/spring-backend-tfg:1.1.0 .
-
-# Cambio breaking
-docker build -t isidromerayo/spring-backend-tfg:2.0.0 .
+# O especificar manualmente
+./scripts/publish-images.sh --version 1.0.0
 ```
 
-##### Script de publicación automatizado
+##### Script de publicación
 
-Puedes crear un script `publish-image.sh` para automatizar el proceso:
+Usa los scripts incluidos en el proyecto:
 
 ```bash
-#!/bin/bash
-set -e
+# Backend
+./scripts/publish-images.sh
 
-VERSION=$1
-if [ -z "$VERSION" ]; then
-    echo "Uso: ./publish-image.sh <version>"
-    echo "Ejemplo: ./publish-image.sh 1.0.0"
-    exit 1
-fi
-
-IMAGE_NAME="isidromerayo/spring-backend-tfg"
-
-echo "🔨 Compilando aplicación..."
-./mvnw clean install
-
-echo "🐳 Construyendo imagen Docker..."
-docker build -t ${IMAGE_NAME}:${VERSION} .
-docker tag ${IMAGE_NAME}:${VERSION} ${IMAGE_NAME}:latest
-
-echo "📤 Publicando en Docker Hub..."
-docker push ${IMAGE_NAME}:${VERSION}
-docker push ${IMAGE_NAME}:latest
-
-echo "✅ Imagen publicada correctamente:"
-echo "   - ${IMAGE_NAME}:${VERSION}"
-echo "   - ${IMAGE_NAME}:latest"
-```
-
-Uso:
-```bash
-chmod +x publish-image.sh
-./publish-image.sh 1.0.0
+# PostgreSQL
+POSTGRES_PASSWORD=mi_password ./scripts/publish-db-image.sh 1.0
 ```
 
 ##### Troubleshooting
@@ -752,11 +579,11 @@ podman --version
 
 Todos los comandos Docker funcionan con Podman reemplazando `docker` por `podman`:
 
-##### Ejecutar MariaDB con Podman
+##### Ejecutar PostgreSQL con Podman
 
 ```bash
-# Equivalente a: docker run --name mariadb-tfg -p 3306:3306 -d isidromerayo/mariadb-tfg
-podman run --name mariadb-tfg -p 3306:3306 -d isidromerayo/mariadb-tfg
+# Equivalente a: docker run --name postgres-tfg -p 5432:5432 -d postgres:17
+podman run --name postgres-tfg -p 5432:5432 -d postgres:17
 ```
 
 ##### Construir imagen del backend con Podman
@@ -823,7 +650,7 @@ podman run -d --pod backend-pod --name postgres_db \
   -e POSTGRES_PASSWORD=mypass \
   -e POSTGRES_DB=tfg_unir \
   -e POSTGRES_USER=user_tfg \
-  postgres:latest
+  postgres:17
 ```
 
 **3. Ejecutar el backend en el pod**

--- a/docs/docker/DOCKER_IMAGES_GUIDE.md
+++ b/docs/docker/DOCKER_IMAGES_GUIDE.md
@@ -2,10 +2,32 @@
 
 ## Introducción
 
-Este proyecto proporciona dos formas de obtener las imágenes Docker necesarias:
+Este proyecto proporciona imágenes Docker para el backend y la base de datos PostgreSQL:
 
 1. **Descargar desde Docker Hub** (recomendado) - Imágenes pre-construidas
 2. **Construir localmente** - Para desarrollo o personalización
+
+### Release Flow
+
+```bash
+# 1. Preparar release (elimina -SNAPSHOT, crea tag vX.Y.Z)
+mvn release:prepare
+
+# 2. Compilar desde el tag
+git checkout vX.Y.Z && ./mvnw clean package -DskipTests
+
+# 3. Publicar backend (valida que NO sea SNAPSHOT)
+./scripts/publish-images.sh
+
+# 4. Verificar lo que se publicaría sin ejecutar
+./scripts/publish-images.sh --dry-run
+
+# 5. (Opcional) Publicar BD si hay cambios estructurales
+POSTGRES_PASSWORD=<password> ./scripts/publish-db-image.sh 1.1
+
+# 6. Volver a main y subir tags
+git checkout main && git push origin main --tags
+```
 
 ---
 
@@ -21,12 +43,12 @@ Este proyecto proporciona dos formas de obtener las imágenes Docker necesarias:
 
 ```bash
 # Con Docker
-docker pull isidromerayo/mariadb-tfg:0.1.0
-docker pull isidromerayo/spring-backend-tfg:0.4.0
+docker pull isidromerayo/postgres-tfg:1.0
+docker pull isidromerayo/spring-backend-tfg:0.6.2
 
 # Con Podman
-podman pull docker.io/isidromerayo/mariadb-tfg:0.1.0
-podman pull docker.io/isidromerayo/spring-backend-tfg:0.4.0
+podman pull docker.io/isidromerayo/postgres-tfg:1.0
+podman pull docker.io/isidromerayo/spring-backend-tfg:0.6.2
 ```
 
 ### Usar con Docker Compose
@@ -35,12 +57,12 @@ El archivo `docker-compose.yml` ya está configurado para usar estas imágenes:
 
 ```yaml
 services:
-  maria_db:
-    image: "isidromerayo/mariadb-tfg:0.1.0"
+  postgres_db:
+    image: "isidromerayo/postgres-tfg:1.0"
     # ...
 
   api_service:
-    image: "isidromerayo/spring-backend-tfg:0.4.0"
+    image: "isidromerayo/spring-backend-tfg:0.6.2"
     # ...
 ```
 
@@ -84,32 +106,36 @@ cd TFG_UNIR-backend
 
 Esto genera `target/backend.jar` (~60MB)
 
-#### 2. Construir Imagen de MariaDB
+#### 2. Construir Imagen de PostgreSQL
 
 **Con Docker:**
 ```bash
-docker build -f Dockerfile-db -t isidromerayo/mariadb-tfg:0.1.0 .
-docker tag isidromerayo/mariadb-tfg:0.1.0 isidromerayo/mariadb-tfg:latest
+POSTGRES_PASSWORD=mi_password docker build -f Dockerfile-db-postgresql \
+    --build-arg POSTGRES_PASSWORD=mi_password \
+    -t isidromerayo/postgres-tfg:1.0 .
+docker tag isidromerayo/postgres-tfg:1.0 isidromerayo/postgres-tfg:latest
 ```
 
 **Con Podman:**
 ```bash
-podman build -f Dockerfile-db -t localhost/isidromerayo/mariadb-tfg:0.1.0 .
-podman tag localhost/isidromerayo/mariadb-tfg:0.1.0 localhost/isidromerayo/mariadb-tfg:latest
+POSTGRES_PASSWORD=mi_password podman build -f Dockerfile-db-postgresql \
+    --build-arg POSTGRES_PASSWORD=mi_password \
+    -t localhost/isidromerayo/postgres-tfg:1.0 .
+podman tag localhost/isidromerayo/postgres-tfg:1.0 localhost/isidromerayo/postgres-tfg:latest
 ```
 
 #### 3. Construir Imagen del Backend
 
 **Con Docker:**
 ```bash
-docker build -t isidromerayo/spring-backend-tfg:0.4.0 .
-docker tag isidromerayo/spring-backend-tfg:0.4.0 isidromerayo/spring-backend-tfg:latest
+docker build --build-arg VERSION=0.6.2 -t isidromerayo/spring-backend-tfg:0.6.2 .
+docker tag isidromerayo/spring-backend-tfg:0.6.2 isidromerayo/spring-backend-tfg:latest
 ```
 
 **Con Podman:**
 ```bash
-podman build -t localhost/isidromerayo/spring-backend-tfg:0.4.0 .
-podman tag localhost/isidromerayo/spring-backend-tfg:0.4.0 localhost/isidromerayo/spring-backend-tfg:latest
+podman build --build-arg VERSION=0.6.2 -t localhost/isidromerayo/spring-backend-tfg:0.6.2 .
+podman tag localhost/isidromerayo/spring-backend-tfg:0.6.2 localhost/isidromerayo/spring-backend-tfg:latest
 ```
 
 #### 4. Verificar Imágenes Construidas
@@ -126,9 +152,9 @@ podman images | grep isidromerayo
 
 Deberías ver:
 ```
-isidromerayo/mariadb-tfg          0.1.0    ...    ...    ...
-isidromerayo/mariadb-tfg          latest   ...    ...    ...
-isidromerayo/spring-backend-tfg   0.4.0    ...    ...    ...
+isidromerayo/postgres-tfg          1.0      ...    ...    ...
+isidromerayo/postgres-tfg          latest   ...    ...    ...
+isidromerayo/spring-backend-tfg   0.6.2    ...    ...    ...
 isidromerayo/spring-backend-tfg   latest   ...    ...    ...
 ```
 
@@ -172,62 +198,53 @@ Luego ejecuta:
 
 ---
 
-## Publicar Imágenes en Docker Hub (Opcional)
-
-Si quieres publicar tus propias versiones en Docker Hub:
+## Publicar Imágenes en Docker Hub
 
 ### Requisitos
 
 - Cuenta en [Docker Hub](https://hub.docker.com/)
-- Autenticación configurada
+- Autenticación configurada (`docker login` o `podman login`)
+- Backend compilado (`./mvnw clean package -DskipTests`)
 
-### Pasos
-
-#### 1. Autenticarse
-
-**Con Docker:**
-```bash
-docker login
-```
-
-**Con Podman:**
-```bash
-podman login docker.io
-```
-
-Te pedirá:
-- **Username**: tu usuario de Docker Hub
-- **Password**: tu contraseña o token de acceso
-
-#### 2. Construir y Publicar
-
-Usa el script automatizado:
+### Publicar imagen del backend
 
 ```bash
+# Verificar qué se publicaría (sin ejecutar)
+./scripts/publish-images.sh --dry-run
+
+# Publicar
 ./scripts/publish-images.sh
 ```
 
-Este script:
-1. Verifica que el backend esté compilado
-2. Construye ambas imágenes
-3. Las etiqueta con versión y `:latest`
-4. Verifica autenticación
-5. Publica en Docker Hub
+El script:
+- Extrae la versión del `pom.xml`
+- Rechaza versiones SNAPSHOT
+- Construye con `--build-arg VERSION`
+- Publica con tags `:version` y `:latest`
 
-#### 3. Publicación Manual
+### Publicar imagen de PostgreSQL
+
+```bash
+# Requiere POSTGRES_PASSWORD como variable de entorno
+POSTGRES_PASSWORD=mi_password ./scripts/publish-db-image.sh 1.0
+```
+
+### Publicación manual
 
 Si prefieres hacerlo manualmente:
 
 ```bash
-# Construir imágenes (ver sección anterior)
-
-# Publicar MariaDB
-docker push isidromerayo/mariadb-tfg:0.1.0
-docker push isidromerayo/mariadb-tfg:latest
-
-# Publicar Backend
-docker push isidromerayo/spring-backend-tfg:0.4.0
+# Backend
+docker build --build-arg VERSION=0.6.2 -t isidromerayo/spring-backend-tfg:0.6.2 .
+docker push isidromerayo/spring-backend-tfg:0.6.2
 docker push isidromerayo/spring-backend-tfg:latest
+
+# PostgreSQL
+docker build -f Dockerfile-db-postgresql \
+    --build-arg POSTGRES_PASSWORD=mi_password \
+    -t isidromerayo/postgres-tfg:1.0 .
+docker push isidromerayo/postgres-tfg:1.0
+docker push isidromerayo/postgres-tfg:latest
 ```
 
 ---
@@ -247,22 +264,19 @@ docker push isidromerayo/spring-backend-tfg:latest
 
 ## Versiones Disponibles
 
-### MariaDB
+### PostgreSQL
 
-| Tag | Descripción | Tamaño |
-|-----|-------------|--------|
-| `0.1.0` | Versión estable con BCrypt | ~400MB |
-| `latest` | Última versión (actualmente 0.1.0) | ~400MB |
-| `0.0.4` | ⚠️ Versión antigua sin BCrypt | ~400MB |
+| Tag | Descripción |
+|-----|-------------|
+| `1.0` | PostgreSQL 17, imagen base para el proyecto |
+| `latest` | Referencia a la última versión |
 
 ### Backend
 
-| Tag | Descripción | Tamaño |
-|-----|-------------|--------|
-| `0.4.0` | **Última versión** (Spring Boot 3.5) | ~450MB |
-| `latest` | Referencia a la última versión (`0.4.0`) | ~450MB |
-| `0.3.0` | Versión estable anterior (Spring Boot 3.4) | ~450MB |
-| `0.2.2` | ⚠️ Versión antigua sin BCrypt | ~450MB |
+| Tag | Descripción |
+|-----|-------------|
+| `0.6.2` | **Última versión** (Spring Boot 3.5.16) |
+| `latest` | Referencia a la última versión |
 
 ---
 
@@ -329,8 +343,8 @@ Resultado esperado:
 ```bash
 # Construir localmente
 ./mvnw clean package -DskipTests
-docker build -f Dockerfile-db -t isidromerayo/mariadb-tfg:0.1.0 .
-docker build -t isidromerayo/spring-backend-tfg:0.4.0 .
+docker build -f Dockerfile-db-postgresql --build-arg POSTGRES_PASSWORD=xxx -t isidromerayo/postgres-tfg:1.0 .
+docker build --build-arg VERSION=0.6.2 -t isidromerayo/spring-backend-tfg:0.6.2 .
 ```
 
 ### Error: "unauthorized: incorrect username or password"
@@ -435,20 +449,21 @@ docker compose up -d
 
 ## Referencias
 
-- [Dockerfile-db](../Dockerfile-db) - Dockerfile de MariaDB
-- [Dockerfile](../Dockerfile) - Dockerfile del Backend
-- [docker-compose.yml](../docker-compose.yml) - Configuración Docker Compose
-- [CHANGELOG_IMAGES.md](../CHANGELOG_IMAGES.md) - Changelog de versiones
-- [scripts/publish-images.sh](../scripts/publish-images.sh) - Script de publicación
+- [Dockerfile-db-postgresql](../../Dockerfile-db-postgresql) - Dockerfile de PostgreSQL
+- [Dockerfile](../../Dockerfile) - Dockerfile del Backend
+- [docker-compose.yml](../../docker-compose.yml) - Configuración Docker Compose
+- [scripts/publish-images.sh](../../scripts/publish-images.sh) - Publicar imagen del backend
+- [scripts/publish-db-image.sh](../../scripts/publish-db-image.sh) - Publicar imagen de PostgreSQL
+- [AGENTS.md](../../AGENTS.md) - Release Flow
 
 ---
 
 ## Soporte
 
 ### Documentación
-- [SECURITY_BCRYPT.md](../SECURITY_BCRYPT.md) - Guía de seguridad
-- [docs/PODMAN_GUIDE.md](PODMAN_GUIDE.md) - Guía de Podman
-- [docs/security/](security/) - Documentación de seguridad
+- [AGENTS.md](../../AGENTS.md) - Release Flow y reglas del proyecto
+- [scripts/README.md](../../scripts/README.md) - Documentación de scripts
+- [docs/security/](../security/) - Documentación de seguridad
 
 ### Comunidad
 - GitHub Issues - Reportar problemas

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,26 +4,73 @@ Scripts de utilidad para el backend TFG UNIR.
 
 ## Scripts Disponibles
 
-### 🔐 Seguridad y BCrypt
+### 🐳 Publicación de Imágenes Docker
 
 #### `publish-images.sh`
-Script para construir y publicar imágenes en Docker Hub.
+Script para construir y publicar la imagen del backend en Docker Hub. Solo publica versiones que **no** sean SNAPSHOT.
 
 **Uso:**
 ```bash
+# Publicar con versión extraída del pom.xml
 ./scripts/publish-images.sh
+
+# Solo mostrar qué haría (sin ejecutar)
+./scripts/publish-images.sh --dry-run
+
+# Especificar versión manualmente
+./scripts/publish-images.sh --version 0.6.2
+
+# Omitir login en Docker Hub
+./scripts/publish-images.sh --skip-login
 ```
 
+**Flags:**
+| Flag | Descripción |
+|------|-------------|
+| `--version X.Y.Z` | Sobrescribe la versión detectada del pom.xml |
+| `--dry-run` | Muestra los comandos sin ejecutarlos |
+| `--skip-login` | Omite la verificación de login en Docker Hub |
+
 **Qué hace:**
-1. Construye imagen de MariaDB v0.1.0
-2. Construye imagen de Backend v0.3.0
-3. Etiqueta con :latest
-4. Verifica autenticación en Docker Hub
-5. Publica todas las imágenes
+1. Extrae la versión del `pom.xml` (valida formato semver)
+2. Rechaza versiones SNAPSHOT
+3. Construye la imagen del backend con `--build-arg VERSION`
+4. Etiqueta con `:version` y `:latest`
+5. Publica en Docker Hub
 
 **Requisitos:**
 - Backend compilado (`./mvnw clean package`)
 - Autenticado en Docker Hub (`docker login` o `podman login`)
+
+#### `publish-db-image.sh`
+Script para construir y publicar la imagen de PostgreSQL en Docker Hub.
+
+**Uso:**
+```bash
+# Publicar con versión por defecto (1.0)
+POSTGRES_PASSWORD=<tu_password> ./scripts/publish-db-image.sh
+
+# Versión específica
+POSTGRES_PASSWORD=<tu_password> ./scripts/publish-db-image.sh 1.1
+
+# Solo mostrar qué haría
+POSTGRES_PASSWORD=<tu_password> ./scripts/publish-db-image.sh --dry-run
+```
+
+**Variables de entorno requeridas:**
+| Variable | Descripción | Default |
+|----------|-------------|---------|
+| `POSTGRES_PASSWORD` | Contraseña de PostgreSQL (**obligatoria**) | - |
+| `POSTGRES_DB` | Nombre de la base de datos | `tfg_unir` |
+| `POSTGRES_USER` | Usuario de PostgreSQL | `user_tfg` |
+
+**Qué hace:**
+1. Valida que `POSTGRES_PASSWORD` esté definido
+2. Construye la imagen de PostgreSQL con credenciales como `--build-arg`
+3. Etiqueta con `:version` y `:latest`
+4. Publica en Docker Hub
+
+> **⚠️ Seguridad**: Las credenciales **nunca** se hardcodean en el Dockerfile. Se pasan como variables de entorno y `--build-arg` en tiempo de build.
 
 #### `build-and-test-bcrypt.sh`
 Script automatizado completo para construir y probar la migración a BCrypt.
@@ -107,98 +154,81 @@ Script para gestionar contenedores con Podman Pod (alternativa a docker-compose)
 ## Estructura de Directorios
 
 ```
-TFG_UNIR-backend/
-├── scripts/
-│   ├── README.md                    # Este archivo
-│   ├── build-and-test-bcrypt.sh     # Build y test BCrypt
-│   ├── test-login.sh                # Pruebas de login
-│   └── podman-pod.sh                # Gestión Podman Pod
-├── docs/
-│   └── security/
-│       ├── QUICK_START_BCRYPT.md           # Inicio rápido
-│       ├── BCRYPT_MIGRATION_SUMMARY.md     # Resumen completo
-│       ├── BUILD_AND_TEST_BCRYPT.md        # Guía detallada
-│       ├── PR_SNYK_TIMING_ATTACK.md        # PR timing attack
-│       └── SNYK_SECURITY_ISSUE.md          # Issue Snyk
-└── ...
+scripts/
+├── README.md                    # Este archivo
+├── publish-images.sh            # Publicar imagen del backend
+├── publish-db-image.sh          # Publicar imagen de PostgreSQL
+├── build-and-test-bcrypt.sh     # Build y test BCrypt
+├── test-login.sh                # Pruebas de login
+└── podman-pod.sh                # Gestión Podman Pod
 ```
 
 ## Quick Start
 
-Para empezar rápidamente con BCrypt:
+### Publicar imágenes del backend
 
 ```bash
-# 1. Ejecutar script automatizado
-./scripts/build-and-test-bcrypt.sh
+# 1. Compilar
+./mvnw clean package -DskipTests
 
-# 2. Si todo pasa, probar login
-./scripts/test-login.sh
+# 2. Verificar qué se publicaría
+./scripts/publish-images.sh --dry-run
 
-# 3. Probar desde frontend
-cd ../TFG_UNIR-angular
-pnpm start
-# Login: maria@localhost / 1234
+# 3. Publicar
+./scripts/publish-images.sh
+```
+
+### Publicar imagen de PostgreSQL
+
+```bash
+# Requiere POSTGRES_PASSWORD como variable de entorno
+POSTGRES_PASSWORD=mi_password_secreto ./scripts/publish-db-image.sh 1.0
+```
+
+### Probar login
+
+```bash
+./scripts/test-login.sh maria@localhost 1234
 ```
 
 ## Documentación
 
 Para más información, consulta:
 
-- **Quick Start**: `docs/security/QUICK_START_BCRYPT.md`
-- **Resumen Completo**: `docs/security/BCRYPT_MIGRATION_SUMMARY.md`
-- **Guía Detallada**: `docs/security/BUILD_AND_TEST_BCRYPT.md`
+- **Release Flow**: Ver `AGENTS.md` sección "Release Flow (Docker images)"
+- **Guía Docker**: `docs/docker/DOCKER_IMAGES_GUIDE.md`
+- **Quick Start BCrypt**: `docs/security/QUICK_START_BCRYPT.md`
 
 ## Troubleshooting
 
-### Script falla con "Dockerfile-db no encontrado"
+### publish-db-image.sh falla con "POSTGRES_PASSWORD no está definido"
 
-Ejecuta el script desde el directorio correcto:
+Define la variable de entorno antes de ejecutar:
 ```bash
-cd TFG_UNIR-backend
-./scripts/build-and-test-bcrypt.sh
+POSTGRES_PASSWORD=tu_password ./scripts/publish-db-image.sh
+```
+
+### publish-images.sh falla con "No se publican imágenes SNAPSHOT"
+
+La versión detectada del `pom.xml` contiene `-SNAPSHOT`. Ejecuta primero:
+```bash
+mvn release:prepare
+```
+
+### Script falla con "Backend no compilado"
+
+Compila el backend primero:
+```bash
+./mvnw clean package -DskipTests
 ```
 
 ### Usando Podman en lugar de Docker
 
-Si usas Podman y tienes problemas con DNS (`UnknownHostException: maria_db`):
+Si usas Podman y tienes problemas con DNS (`UnknownHostException`):
 
 ```bash
 # Usa el script de Podman Pod en lugar de podman-compose
 ./scripts/podman-pod.sh start
-
-# Ver guía completa
-cat docs/PODMAN_GUIDE.md
-```
-
-### Login falla con credenciales correctas
-
-Reinicia con volúmenes limpios:
-
-**Docker:**
-```bash
-docker compose down -v
-docker compose up -d
-```
-
-**Podman:**
-```bash
-./scripts/podman-pod.sh stop
-podman volume rm tfg_unir-backend_data
-./scripts/podman-pod.sh start
-```
-
-### Backend no inicia
-
-Verifica logs:
-
-**Docker:**
-```bash
-docker compose logs -f api_service
-```
-
-**Podman:**
-```bash
-./scripts/podman-pod.sh logs api
 ```
 
 ## Contribuir


### PR DESCRIPTION
### Cambios

- **AGENTS.md**: nueva sección "Documentation Workflow" con tabla de qué actualizar por tipo de cambio
- **scripts/README.md**: documentación completa de `publish-images.sh` y `publish-db-image.sh` con flags
- **docs/docker/DOCKER_IMAGES_GUIDE.md**: reemplazado MariaDB → PostgreSQL, añadido Release Flow, versiones actualizadas
- **README.md**: secciones Docker actualizadas: PostgreSQL, scripts automatizados, eliminado script manual obsoleto

### Verificación

- [x] Tests unitarios pasan
- [x] SpotBugs pasa
- [x] No se commita directamente a main