### PR TITLE
fix: remove MariaDB legacy and enhance AGENTS.md

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -30,7 +30,7 @@ engines:
     exclude_paths:
       - 'src/test/**'
   
-  # Desactivar análisis SQL Server (no aplica a H2/MariaDB)
+  # Desactivar análisis SQL Server (no aplica a H2/PostgreSQL)
   tsqllint:
     enabled: false
   

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,11 +31,18 @@
 
 ## Non-Negotiable Rules
 1. **TDD mandatory** - failing test before production code
-2. **No direct commits to main** - use feature branches
+2. **Always create a branch** - never work directly on `main`:
+   - `feature/` — new functionality
+   - `fix/` — bug fixes
+   - `fix/remove-` — removing legacy code/dependencies
+   - `security/` — vulnerability fixes (third-party or project)
+   - `docs/` — documentation-only changes
+   - `refactor/` — code restructuring
+   - `chore/` — maintenance (deps, CI, config)
 3. **SpotBugs must pass** before commit
 4. **Never log secrets** (passwords, tokens)
 5. **Validate inputs** with Jakarta annotations (`@Valid`, `@NotBlank`, `@Email`)
-6. **Update docs** - review and update README/docs when changing features or config
+6. **Update docs before PR** - review and update affected documentation (see Documentation Workflow)
 
 ## Code Conventions
 - Constructor injection with `final` fields
@@ -77,12 +84,13 @@ When making changes, update the affected docs **before commit**:
 | Security change | `docs/security/` relevant file, `AGENTS.md` Known Vulnerabilities |
 | Dependency upgrade | `pom.xml` versions, `AGENTS.md` Stack section |
 | New feature/bugfix | `README.md` if user-facing |
+| Removing legacy code | Update all references to removed files/commands |
 
-**Quick check before commit:**
-```bash
-# Verify docs mention new script/feature
-grep -r "new-feature-name" docs/ scripts/README.md README.md
-```
+**Pre-PR checklist:**
+- [ ] All affected documentation updated
+- [ ] `grep -r "removed-feature" docs/ scripts/ README.md` returns no stale references
+- [ ] No broken links to deleted files
+- [ ] `AGENTS.md` Stack section updated if dependencies changed
 
 ## Tooling
 - JUnit 5 + Mockito + AssertJ
@@ -103,4 +111,4 @@ These CVEs are flagged by the CPE matcher but do **not** affect the project:
 `springboot-tdd`, `springboot-security`, `springboot-patterns`, `xp-tdd-practices`, `testing-standards`, `action-tdd`, `task-validate`, `task-testing-review`
 
 ---
-**Updated:** 2026-06-28
+**Updated:** 2026-07-26

--- a/Dockerfile-db-mariadb
+++ b/Dockerfile-db-mariadb
@@ -1,8 +1,0 @@
-FROM docker.io/mariadb:latest
-
-ENV MARIADB_ROOT_PASSWORD=mypass
-ENV MYSQL_DATABASE=tfg_unir
-ENV MYSQL_USER=user_tfg
-ENV MYSQL_PASSWORD=tfg_un1r_PWD
-
-EXPOSE 3306

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ $ psql --version
 psql (PostgreSQL) 15.x
 ```
 
-> ℹ️ **Soporte Legacy**: Si necesitas utilizar **MariaDB** o **MySQL**, consulta la [Guía de Uso de MariaDB/MySQL](docs/MARIADB_MYSQL_GUIDE.md).
+> ℹ️ **Base de datos**: PostgreSQL es la única base de datos soportada.
 
 ##### Crear base de datos y usuario
 
@@ -395,7 +395,7 @@ http://localhost:8080/swagger-ui.html
 
 #### Docker Spring Boot 
 
-Construir imagen de aplicación con el jar generado del backend (con el `spring.datasource.url=jdbc:mariadb://app_db:3306/tfg_unir` en el application.properties) hay que ejecutar un maven para generar
+Construir imagen de aplicación con el jar generado del backend (con el `spring.datasource.url=jdbc:postgresql://app_db:5432/tfg_unir` en el application.properties) hay que ejecutar un maven para generar
 
 
 ```
@@ -405,7 +405,6 @@ docker build -t isidromerayo/spring-backend-tfg:VERSION-X.Y.Z .
 ```
 
 https://spring.io/guides/topicals/spring-boot-docker/
-https://javatodev.com/docker-compose-for-spring-boot-with-mariadb/
 
 #### 🐳 docker compose
 
@@ -616,7 +615,7 @@ cd backend
 # Ver logs del API
 ./scripts/podman-pod.sh logs
 
-# Ver logs de MariaDB
+# Ver logs de PostgreSQL
 ./scripts/podman-pod.sh logs db
 
 # Detener el backend
@@ -628,7 +627,7 @@ cd backend
 
 El script automáticamente:
 - Crea el pod con los puertos necesarios
-- Inicia MariaDB con los datos precargados
+- Inicia PostgreSQL con los datos precargados
 - Inicia el backend API
 - Verifica que los archivos SQL existen
 
@@ -757,12 +756,12 @@ podman ps
 podman ps -a  # Incluir detenidos
 
 # Ver logs
-podman logs mariadb-tfg
+podman logs postgres-tfg
 podman logs -f api_service  # Seguir logs en tiempo real
 
 # Detener y eliminar contenedores
-podman stop mariadb-tfg
-podman rm mariadb-tfg
+podman stop postgres-tfg
+podman rm postgres-tfg
 
 # Listar imágenes
 podman images
@@ -774,7 +773,7 @@ podman rmi isidromerayo/spring-backend-tfg:X.Y.Z
 podman system prune -a
 
 # Generar YAML de Kubernetes desde contenedor
-podman generate kube mariadb-tfg > mariadb-k8s.yaml
+podman generate kube postgres-tfg > postgres-k8s.yaml
 ```
 
 #### Troubleshooting Podman
@@ -789,7 +788,7 @@ sudo sysctl --system
 **Problema: "cannot find image locally"**
 ```bash
 # Especificar el registry completo
-podman pull docker.io/isidromerayo/mariadb-tfg:latest
+podman pull docker.io/isidromerayo/postgres-tfg:latest
 ```
 
 **Problema: Podman compose no funciona**

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -25,7 +25,9 @@ TFG_UNIR-backend/
 │
 ├── 📂 scripts/                     # Scripts ejecutables
 │   ├── README.md                   # Documentación de scripts
-│   ├── build-and-test-bcrypt.sh    # 🔐 Build y test BCrypt (principal)
+│   ├── publish-images.sh           # 🐳 Publicar imagen del backend
+│   ├── publish-db-image.sh         # 🐳 Publicar imagen de PostgreSQL
+│   ├── build-and-test-bcrypt.sh    # 🔐 Build y test BCrypt
 │   ├── test-login.sh               # 🔐 Pruebas de login
 │   └── podman-pod.sh               # 🐳 Gestión de contenedores Podman
 │
@@ -49,7 +51,6 @@ TFG_UNIR-backend/
 │   │   ├── PODMAN_GUIDE.md
 │   │   └── releases/               # Releases de imágenes
 │   ├── database/                   # 🗄️ Bases de datos
-│   │   ├── MARIADB_MYSQL_GUIDE.md
 │   │   └── PR_POSTGRESQL_MIGRATION.md
 │   ├── migration/                  # 🔄 Migraciones de versión
 │   │   ├── SPRING_BOOT_3.5_MIGRATION.md
@@ -65,8 +66,10 @@ TFG_UNIR-backend/
 │   ├── PASSWORDS_INFO.md           # 🔐 Info de contraseñas
 │   ├── CHANGELOG_PASSWORDS.md      # 🔐 Changelog de contraseñas
 │   ├── verify-passwords.py         # 🔐 Script de verificación
-│   ├── dump.mariadb.sql            # Datos iniciales (con BCrypt)
-│   └── create.mariadb.sql          # Esquema de BD
+│   └── postgresql/                 # Scripts SQL para PostgreSQL
+│       ├── 01-create.sql
+│       ├── 02-create.sql
+│       └── 03-create.sql
 │
 ├── 📂 target/                      # Archivos compilados
 │   ├── site/jacoco/                # Reportes de cobertura combinados
@@ -75,7 +78,7 @@ TFG_UNIR-backend/
 │
 ├── 🐳 docker-compose.yml           # Configuración Docker Compose
 ├── 🐳 Dockerfile                   # Imagen del backend
-├── 🐳 Dockerfile-db                # Imagen de MariaDB
+├── 🐳 Dockerfile-db-postgresql     # Imagen de PostgreSQL
 │
 └── 📦 pom.xml                      # Configuración Maven
 ```
@@ -137,16 +140,18 @@ docs/quality/SONARQUBE_ISSUES.md → Issues detectados
 
 ### 🔧 Scripts
 - **Índice**: [scripts/README.md](scripts/README.md)
+- **Publicar backend**: `scripts/publish-images.sh`
+- **Publicar PostgreSQL**: `scripts/publish-db-image.sh`
 - **BCrypt**: `scripts/build-and-test-bcrypt.sh`
 - **Login**: `scripts/test-login.sh`
 - **Podman Pod**: `scripts/podman-pod.sh`
 
 ### 🐳 Contenedores
+- **Guía Docker**: [docs/docker/DOCKER_IMAGES_GUIDE.md](docs/docker/DOCKER_IMAGES_GUIDE.md)
 - **Guía Podman**: [docs/docker/PODMAN_GUIDE.md](docs/docker/PODMAN_GUIDE.md)
-- **Guía Docker**: [docs/docker/DOCKER_WORKFLOW.md](docs/docker/DOCKER_WORKFLOW.md)
 - **Docker Compose**: `docker-compose.yml`
 - **Dockerfile Backend**: `Dockerfile`
-- **Dockerfile MariaDB**: `Dockerfile-db`
+- **Dockerfile PostgreSQL**: `Dockerfile-db-postgresql`
 
 ### 📊 Calidad
 - **Cobertura**: [docs/quality/COVERAGE_ANALYSIS.md](docs/quality/COVERAGE_ANALYSIS.md)
@@ -163,10 +168,8 @@ docs/quality/SONARQUBE_ISSUES.md → Issues detectados
 - **Contraseñas**: [recursos/db/PASSWORDS_INFO.md](recursos/db/PASSWORDS_INFO.md)
 - **Changelog**: [recursos/db/CHANGELOG_PASSWORDS.md](recursos/db/CHANGELOG_PASSWORDS.md)
 - **Verificación**: `recursos/db/verify-passwords.py`
-- **Datos**: `recursos/db/dump.mariadb.sql`
-- **Esquema**: `recursos/db/create.mariadb.sql`
-- **MariaDB/MySQL**: [docs/database/MARIADB_MYSQL_GUIDE.md](docs/database/MARIADB_MYSQL_GUIDE.md)
-- **PostgreSQL**: [docs/database/PR_POSTGRESQL_MIGRATION.md](docs/database/PR_POSTGRESQL_MIGRATION.md)
+- **PostgreSQL**: `recursos/db/postgresql/`
+- **Migración**: [docs/database/PR_POSTGRESQL_MIGRATION.md](docs/database/PR_POSTGRESQL_MIGRATION.md)
 
 ## 🎯 Casos de Uso Comunes
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,6 @@ Guías de Docker, Podman y contenedores.
 ### `/database/`
 Documentación sobre bases de datos y migraciones.
 
-- **[MARIADB_MYSQL_GUIDE.md](database/MARIADB_MYSQL_GUIDE.md)** - Guía de MariaDB/MySQL
 - **[PR_POSTGRESQL_MIGRATION.md](database/PR_POSTGRESQL_MIGRATION.md)** - Migración a PostgreSQL
 
 ### `/migration/`

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -154,7 +154,7 @@ boolean matches = passwordEncoder.matches(password, storedHash);
 
 ### Configuración
 - `../../docker-compose.yml` - Configuración Docker
-- `../../Dockerfile-db` - Imagen MariaDB
+- `../../Dockerfile-db-postgresql` - Imagen PostgreSQL
 
 ## 🆘 Soporte
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -72,28 +72,10 @@ POSTGRES_PASSWORD=<tu_password> ./scripts/publish-db-image.sh --dry-run
 
 > **⚠️ Seguridad**: Las credenciales **nunca** se hardcodean en el Dockerfile. Se pasan como variables de entorno y `--build-arg` en tiempo de build.
 
-#### `build-and-test-bcrypt.sh`
-Script automatizado completo para construir y probar la migración a BCrypt.
+#### `build-and-test-bcrypt.sh` *(DEPRECATED - legacy MariaDB)*
+Script legacy que verificaba BCrypt en MariaDB. Ya no es funcional tras la migración a PostgreSQL.
 
-**Uso:**
-```bash
-./scripts/build-and-test-bcrypt.sh
-```
-
-**Qué hace:**
-1. Verifica contraseñas BCrypt en dump.mariadb.sql
-2. Construye nueva imagen Docker (isidromerayo/mariadb-tfg:0.0.5-bcrypt)
-3. Reinicia contenedores con volúmenes limpios
-4. Verifica contraseñas hasheadas en la base de datos
-5. Espera a que el backend esté listo
-6. Prueba autenticación con múltiples usuarios
-7. Valida rechazo de credenciales incorrectas
-8. Muestra resumen de resultados
-
-**Requisitos:**
-- Docker o Podman
-- curl
-- jq (opcional, para formato JSON)
+**Uso:** No usar — se mantiene solo como referencia histórica.
 
 #### `test-login.sh`
 Script simple para probar el login con diferentes usuarios.
@@ -139,7 +121,7 @@ Script para gestionar contenedores con Podman Pod (alternativa a docker-compose)
 ./scripts/podman-pod.sh logs
 ./scripts/podman-pod.sh logs api
 
-# Ver logs de MariaDB
+# Ver logs de PostgreSQL
 ./scripts/podman-pod.sh logs db
 ```
 

--- a/scripts/build-and-test-bcrypt.sh
+++ b/scripts/build-and-test-bcrypt.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
-# Script para construir y probar la nueva imagen de MariaDB con BCrypt
-# Autor: Generado automáticamente
-# Fecha: 2024-12-09
+# DEPRECATED: Este script era para MariaDB con BCrypt (2024).
+# La migración a PostgreSQL ya completó este script ya no es funcional.
+# Se mantiene como referencia histórica.
+
+echo "⚠️  DEPRECATED: Este script es legacy (MariaDB). La migración a PostgreSQL ya completó."
+echo "   Usa scripts/podman-pod.sh o docker-compose.yml para PostgreSQL."
+exit 1
 
 set -e  # Exit on error
 

--- a/scripts/podman-pod.sh
+++ b/scripts/podman-pod.sh
@@ -133,9 +133,9 @@ function logs_pod() {
                 print_info "Logs del backend API:"
                 podman logs --tail 50 $API_SERVICE_CONTAINER
                 ;;
-            db|mariadb)
-                print_info "Logs de MariaDB:"
-                podman logs --tail 50 $MARIA_DB_CONTAINER
+            db|postgres)
+                print_info "Logs de PostgreSQL:"
+                podman logs --tail 50 $POSTGRES_DB_CONTAINER
                 ;;
             *)
                 print_error "Servicio desconocido: $2"
@@ -156,7 +156,7 @@ function show_usage() {
     echo "  status   - Ver el estado del backend"
     echo "  logs     - Ver logs del backend API"
     echo "  logs api - Ver logs del backend API"
-    echo "  logs db  - Ver logs de MariaDB"
+    echo "  logs db  - Ver logs de PostgreSQL"
     echo ""
     echo "Ejemplos:"
     echo "  $0 start"


### PR DESCRIPTION
## Descripción

Elimina todas las referencias legacy a MariaDB del proyecto y mejora AGENTS.md con convenciones de ramas y checklist de documentación pre-PR.

## Cambios

### Eliminación MariaDB legacy
- `Dockerfile-db-mariadb` eliminado
- `scripts/podman-pod.sh`: referencias MariaDB → PostgreSQL
- `scripts/build-and-test-bcrypt.sh`: marcado como DEPRECATED
- `README.md`: notas legacy eliminadas, JDBC URLs actualizadas, comandos podman actualizados
- `STRUCTURE.md`: `MARIADB_MYSQL_GUIDE.md` eliminado del árbol
- `docs/README.md`, `docs/security/README.md`: referencias actualizadas
- `.codacy.yml`: comentario actualizado

### Mejoras AGENTS.md
- Regla 2: "Always create a branch" con 7 prefijos de ramas
- Regla 6: "Update docs before PR" con referencia a Documentation Workflow
- Documentation Workflow: nueva fila "Removing legacy code" + pre-PR checklist

## Tipo de cambio
- [x] 🐛 Bug fix (eliminación de código legacy)
- [x] 📚 Documentación

## Tests
- [x] Los tests unitarios pasan (`./mvnw test` BUILD SUCCESS)
- [x] SpotBugs pasa (`./mvnw compile spotbugs:check` 0 bugs)

## Checklist
- [x] Todos los archivos de documentación afectados actualizados
- [x] No hay referencias rotas a archivos eliminados