### PR TITLE
fix: corregir hallazgos análisis Docker/Podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,8 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1
 
-# Run application
-ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app/app.jar"]
+# Entrypoint con exec para propagar señales SIGTERM directamente a la JVM,
+# habilitando el graceful shutdown de Spring Boot.
+COPY --chown=$USER:$USER docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/Dockerfile-db-postgresql
+++ b/Dockerfile-db-postgresql
@@ -1,11 +1,19 @@
 FROM docker.io/postgres:17
 
-ARG POSTGRES_PASSWORD
+# POSTGRES_DB y POSTGRES_USER no son secretos: se pueden fijar como valores
+# por defecto en la imagen. POSTGRES_PASSWORD NO se embebe aquí para evitar
+# que quede expuesta en el historial de capas (docker history).
+# Se debe pasar en runtime via variable de entorno:
+#   docker run -e POSTGRES_PASSWORD=... ...
+# O a través de docker-compose.yml / podman-pod.sh.
+
 ARG POSTGRES_DB=tfg_unir
 ARG POSTGRES_USER=user_tfg
 
-ENV POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
 ENV POSTGRES_DB=${POSTGRES_DB}
 ENV POSTGRES_USER=${POSTGRES_USER}
+
+LABEL org.opencontainers.image.title="TFG UNIR PostgreSQL"
+LABEL org.opencontainers.image.description="PostgreSQL database for TFG UNIR"
 
 EXPOSE 5432

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# docker-entrypoint.sh
+#
+# Usa exec para reemplazar el proceso shell por la JVM directamente.
+# Esto garantiza que las señales del sistema (SIGTERM, SIGINT) lleguen
+# al proceso Java, permitiendo el graceful shutdown de Spring Boot.
+#
+# Sin exec, sh intercepta SIGTERM pero no lo reenvía a la JVM,
+# lo que provoca que el contenedor espere el timeout antes de forzar la parada.
+
+exec java $JAVA_OPTS -jar /app/app.jar "$@"

--- a/scripts/podman-pod.sh
+++ b/scripts/podman-pod.sh
@@ -8,7 +8,7 @@ POD_NAME="backend-pod"
 POSTGRES_DB_CONTAINER="postgres_db"
 API_SERVICE_CONTAINER="api_service"
 POSTGRES_DB_IMAGE="docker.io/isidromerayo/postgres-tfg:1.0"
-API_SERVICE_IMAGE="docker.io/isidromerayo/spring-backend-tfg:0.5.0"
+API_SERVICE_IMAGE="docker.io/isidromerayo/spring-backend-tfg:0.6.2"
 VOLUME_NAME="tfg_unir-backend_pg_data"
 
 # Cargar variables de entorno desde archivo .env
@@ -69,9 +69,18 @@ function start_pod() {
         -e POSTGRES_USER=${POSTGRES_USER:-user_tfg} \
         $POSTGRES_DB_IMAGE
     
-    # Esperar a que PostgreSQL esté listo
+    # Esperar a que PostgreSQL esté listo con pg_isready
     print_info "Esperando a que PostgreSQL esté listo..."
-    sleep 10
+    RETRIES=30
+    until podman exec $POSTGRES_DB_CONTAINER pg_isready -U "${POSTGRES_USER:-user_tfg}" -d "${POSTGRES_DB:-tfg_unir}" &>/dev/null; do
+        RETRIES=$((RETRIES - 1))
+        if [ $RETRIES -eq 0 ]; then
+            print_error "PostgreSQL no respondió tras 30 intentos"
+            exit 1
+        fi
+        sleep 2
+    done
+    print_info "PostgreSQL listo"
     
     # Ejecutar el backend
     print_info "Iniciando backend API..."
@@ -133,9 +142,9 @@ function logs_pod() {
                 print_info "Logs del backend API:"
                 podman logs --tail 50 $API_SERVICE_CONTAINER
                 ;;
-            db|mariadb)
-                print_info "Logs de MariaDB:"
-                podman logs --tail 50 $MARIA_DB_CONTAINER
+            db|postgres)
+                print_info "Logs de PostgreSQL:"
+                podman logs --tail 50 $POSTGRES_DB_CONTAINER
                 ;;
             *)
                 print_error "Servicio desconocido: $2"
@@ -156,7 +165,7 @@ function show_usage() {
     echo "  status   - Ver el estado del backend"
     echo "  logs     - Ver logs del backend API"
     echo "  logs api - Ver logs del backend API"
-    echo "  logs db  - Ver logs de MariaDB"
+    echo "  logs db  - Ver logs de PostgreSQL"
     echo ""
     echo "Ejemplos:"
     echo "  $0 start"

--- a/scripts/publish-db-image.sh
+++ b/scripts/publish-db-image.sh
@@ -7,6 +7,9 @@
 #   ./publish-db-image.sh              # usa versión por defecto (1.0)
 #   ./publish-db-image.sh 1.1          # versión específica
 #   ./publish-db-image.sh --dry-run    # solo mostrar qué haría
+#
+# NOTA: POSTGRES_PASSWORD NO se embebe en la imagen (evita exposición en
+# docker history). Se pasa en runtime via docker-compose.yml o podman-pod.sh.
 
 set -e
 
@@ -20,11 +23,14 @@ DOCKER_USER="isidromerayo"
 DB_VERSION="1.0"
 DRY_RUN=false
 SKIP_LOGIN=false
-DB_NAME="tfg_unir"
-DB_USER="user_tfg"
-DB_PASSWORD=""
 
-# Procesar argumentos
+# --- Funciones de output ---
+print_step()   { echo -e "${YELLOW}>>> $1${NC}"; }
+print_success(){ echo -e "${GREEN}✓ $1${NC}"; }
+print_error()  { echo -e "${RED}✗ $1${NC}"; }
+print_info()   { echo -e "${BLUE}ℹ $1${NC}"; }
+
+# --- Procesar argumentos ---
 for arg in "$@"; do
   case "$arg" in
     --dry-run)
@@ -34,11 +40,11 @@ for arg in "$@"; do
       SKIP_LOGIN=true
       ;;
     --password)
-      echo "Error: --password no está soportado. Usa la variable de entorno POSTGRES_PASSWORD."
+      print_error "--password no está soportado. Las credenciales se pasan en runtime."
       exit 1
       ;;
     --*)
-      echo "Error: Argumento desconocido: $arg"
+      print_error "Argumento desconocido: $arg"
       echo "Uso: $0 [<version>] [--dry-run] [--skip-login]"
       exit 1
       ;;
@@ -48,24 +54,13 @@ for arg in "$@"; do
   esac
 done
 
-# Credenciales desde variables de entorno (obligatoria para build)
-DB_PASSWORD="${POSTGRES_PASSWORD:-}"
-if [ -z "$DB_PASSWORD" ]; then
-    echo "Error: POSTGRES_PASSWORD no está definido."
-    echo "Define la variable de entorno antes de ejecutar:"
-    echo "  POSTGRES_PASSWORD=<tu_password> ./publish-db-image.sh"
-    exit 1
-fi
+# Los valores de DB y USER no son secretos: se pueden leer del entorno
+# o usar los valores por defecto del Dockerfile.
 DB_NAME="${POSTGRES_DB:-tfg_unir}"
 DB_USER="${POSTGRES_USER:-user_tfg}"
 
 DOCKERFILE="Dockerfile-db-postgresql"
 IMAGE_NAME="${DOCKER_USER}/postgres-tfg"
-
-print_step() { echo -e "${YELLOW}>>> $1${NC}"; }
-print_success() { echo -e "${GREEN}✓ $1${NC}"; }
-print_error() { echo -e "${RED}✗ $1${NC}"; }
-print_info() { echo -e "${BLUE}ℹ $1${NC}"; }
 
 echo -e "${BLUE}========================================${NC}"
 echo -e "${BLUE}Publicar imagen de PostgreSQL en Docker Hub${NC}"
@@ -79,6 +74,7 @@ if [ ! -f "$DOCKERFILE" ]; then
 fi
 
 print_info "Versión: ${DB_VERSION}"
+print_info "POSTGRES_PASSWORD se pasa en runtime (no embebida en la imagen)"
 echo ""
 
 if [ "$DRY_RUN" = true ]; then
@@ -86,6 +82,7 @@ if [ "$DRY_RUN" = true ]; then
     echo ""
 fi
 
+# --- Detectar Docker o Podman ---
 if command -v docker &> /dev/null && docker info &> /dev/null; then
     CONTAINER_CMD="docker"
 elif command -v podman &> /dev/null; then
@@ -97,9 +94,11 @@ fi
 print_info "Usando: $CONTAINER_CMD"
 echo ""
 
-# Construir
+# --- Construir ---
+# POSTGRES_PASSWORD no se pasa como --build-arg: ya no es ARG en el Dockerfile.
+# POSTGRES_DB y POSTGRES_USER sí son ARGs seguros (no son secretos).
 print_step "Construyendo imagen PostgreSQL v${DB_VERSION}..."
-BUILD_ARGS="--build-arg POSTGRES_PASSWORD=${DB_PASSWORD} --build-arg POSTGRES_DB=${DB_NAME} --build-arg POSTGRES_USER=${DB_USER}"
+BUILD_ARGS="--build-arg POSTGRES_DB=${DB_NAME} --build-arg POSTGRES_USER=${DB_USER}"
 TAGS="-t ${IMAGE_NAME}:${DB_VERSION} -t ${IMAGE_NAME}:latest"
 if [ "$DRY_RUN" = true ]; then
     print_info "  $CONTAINER_CMD build -f $DOCKERFILE $BUILD_ARGS $TAGS ."
@@ -108,7 +107,7 @@ else
     print_success "Imagen PostgreSQL construida"
 fi
 
-# Login
+# --- Login ---
 if [ "$SKIP_LOGIN" = false ] && [ "$DRY_RUN" = false ]; then
     print_step "Verificando autenticación en Docker Hub..."
     if ! $CONTAINER_CMD login docker.io --get-login &>/dev/null; then
@@ -122,7 +121,7 @@ if [ "$SKIP_LOGIN" = false ] && [ "$DRY_RUN" = false ]; then
     print_success "Autenticado en Docker Hub"
 fi
 
-# Publicar
+# --- Publicar ---
 print_step "Publicando PostgreSQL v${DB_VERSION}..."
 if [ "$DRY_RUN" = true ]; then
     print_info "  $CONTAINER_CMD push ${IMAGE_NAME}:${DB_VERSION}"
@@ -133,7 +132,7 @@ else
     print_success "PostgreSQL publicado"
 fi
 
-# Resumen
+# --- Resumen ---
 echo ""
 echo -e "${BLUE}========================================${NC}"
 if [ "$DRY_RUN" = true ]; then
@@ -147,5 +146,7 @@ echo "Imagen:"
 echo "   ${IMAGE_NAME}:${DB_VERSION}"
 echo "   ${IMAGE_NAME}:latest"
 echo ""
-echo "Actualiza docker-compose.yml con la nueva versión si es necesario."
+echo "Recuerda pasar POSTGRES_PASSWORD en runtime:"
+echo "  docker compose up -d   (usa .env o variable de entorno)"
+echo "  ./scripts/podman-pod.sh start"
 echo ""

--- a/scripts/publish-images.sh
+++ b/scripts/publish-images.sh
@@ -8,22 +8,39 @@
 
 set -e
 
-# Colores para output
+# --- Colores ---
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
-# Configuración
+# --- Configuración ---
 DOCKER_USER="isidromerayo"
 
-# Flags
+# --- Flags ---
 DRY_RUN=false
 SKIP_LOGIN=false
 CUSTOM_VERSION=""
 
-# Procesar argumentos
+# --- Funciones de output (definidas antes de cualquier uso) ---
+print_step() {
+    echo -e "${YELLOW}>>> $1${NC}"
+}
+
+print_success() {
+    echo -e "${GREEN}✓ $1${NC}"
+}
+
+print_error() {
+    echo -e "${RED}✗ $1${NC}"
+}
+
+print_info() {
+    echo -e "${BLUE}ℹ $1${NC}"
+}
+
+# --- Procesar argumentos ---
 while [ $# -gt 0 ]; do
   case "$1" in
     --dry-run)
@@ -51,7 +68,7 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-# Extraer versión del proyecto del pom.xml (segundo <version>, tras el del parent)
+# --- Extraer versión del proyecto del pom.xml (segundo <version>, tras el del parent) ---
 BACKEND_VERSION=$(grep -o '<version>[^<]*</version>' pom.xml | sed -n '2p' | sed 's|<version>||;s|</version>||')
 
 # Validar que la versión extraída no está vacía y tiene formato semver
@@ -68,22 +85,6 @@ fi
 if [ -n "$CUSTOM_VERSION" ]; then
     BACKEND_VERSION="$CUSTOM_VERSION"
 fi
-
-print_step() {
-    echo -e "${YELLOW}>>> $1${NC}"
-}
-
-print_success() {
-    echo -e "${GREEN}✓ $1${NC}"
-}
-
-print_error() {
-    echo -e "${RED}✗ $1${NC}"
-}
-
-print_info() {
-    echo -e "${BLUE}ℹ $1${NC}"
-}
 
 echo -e "${BLUE}========================================${NC}"
 echo -e "${BLUE}Publicar imagen del Backend en Docker Hub${NC}"


### PR DESCRIPTION
## Descripción

Corrección de los 5 hallazgos detectados durante el análisis de la generación y publicación de imágenes Docker/Podman del backend. Los hallazgos 6 y 7 son informativos y se resuelven automáticamente con el próximo `mvn release:prepare`.

---

## Hallazgos corregidos

### 1 — `podman-pod.sh`: imagen del backend desactualizada (⚠️ Media)
**Archivo:** `scripts/podman-pod.sh`

La variable `API_SERVICE_IMAGE` apuntaba a `0.5.0` siendo `0.6.2` la última publicada.

```diff
-API_SERVICE_IMAGE="docker.io/isidromerayo/spring-backend-tfg:0.5.0"
+API_SERVICE_IMAGE="docker.io/isidromerayo/spring-backend-tfg:0.6.2"
```

---

### 2 — `podman-pod.sh`: variable `$MARIA_DB_CONTAINER` indefinida en `logs_pod()` (⚠️ Media)
**Archivo:** `scripts/podman-pod.sh`

Residuo de la migración MariaDB → PostgreSQL. La función `logs_pod` usaba `$MARIA_DB_CONTAINER` (nunca definida), causando un error en runtime al ejecutar `logs db`.

Cambios aplicados:
- Alias `mariadb` → `postgres` en el `case` de `logs_pod()`
- Referencia corregida a `$POSTGRES_DB_CONTAINER` (variable sí definida)
- `show_usage` actualizado: «logs de MariaDB» → «logs de PostgreSQL»
- `sleep 10` reemplazado por bucle `pg_isready` con timeout de 60 s (30 reintentos × 2 s), coherente con el `healthcheck` del `docker-compose.yml`

---

### 3 — `publish-images.sh`: funciones `print_*` usadas antes de definirse (⚠️ Baja)
**Archivo:** `scripts/publish-images.sh`

Las funciones `print_error`, `print_info`, etc. se llamaban en las validaciones de versión (línea ~42) pero se definían más abajo (línea ~57). Si la versión extraída del `pom.xml` era inválida, el script fallaba con `command not found` en lugar del mensaje de error esperado.

Bloque de funciones movido antes del bloque de extracción y validación de versión.

---

### 4 — `Dockerfile-db-postgresql`: credencial embebida en capas `ENV` (⚠️ Media)
**Archivos:** `Dockerfile-db-postgresql`, `scripts/publish-db-image.sh`

`POSTGRES_PASSWORD` se pasaba como `ARG` y luego se fijaba en `ENV`, quedando visible en el historial de capas de la imagen (`docker history`).

La imagen oficial `postgres:17` lee `POSTGRES_PASSWORD` en runtime desde el entorno del contenedor — no necesita estar en el `Dockerfile`.

Cambios:
- Eliminadas las instrucciones `ARG POSTGRES_PASSWORD` y `ENV POSTGRES_PASSWORD` del `Dockerfile-db-postgresql`
- `POSTGRES_DB` y `POSTGRES_USER` se mantienen como `ARG`/`ENV` (no son secretos)
- `publish-db-image.sh`: eliminado `--build-arg POSTGRES_PASSWORD` del comando de build; eliminada la validación que lo requería como obligatorio; añadido aviso en el resumen de que la contraseña se pasa en runtime

---

### 5 — `Dockerfile`: ENTRYPOINT no propaga señales SIGTERM a la JVM (ℹ️ Baja)
**Archivos:** `Dockerfile`, `docker-entrypoint.sh` *(nuevo)*

La forma `ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS ..."]\ hace que `sh` sea el PID 1 del contenedor. Al recibir `SIGTERM` (ej. `docker stop`), `sh` no reenvía la señal a la JVM, por lo que Spring Boot no puede ejecutar su graceful shutdown y el contenedor espera el timeout completo antes de matarse.

Solución: nuevo script `docker-entrypoint.sh` con `exec java ...`, que reemplaza el proceso `sh` por la JVM (PID 1 real).

```sh
exec java $JAVA_OPTS -jar /app/app.jar "$@"
```

El `Dockerfile` ahora copia el script con `--chown` y lo invoca en exec-form:
```dockerfile
COPY --chown=$USER:$USER docker-entrypoint.sh /app/docker-entrypoint.sh
RUN chmod +x /app/docker-entrypoint.sh
ENTRYPOINT ["/app/docker-entrypoint.sh"]
```

---

## Hallazgos pendientes (informativos, sin acción manual)

| # | Hallazgo | Resolución |
|---|---|---|
| 6 | `docker-compose.yml` fijado en `0.6.2`, pom en `0.6.3-SNAPSHOT` | Se actualiza tras el próximo `mvn release:prepare` + `publish-images.sh` |
| 7 | Tag SCM del `pom.xml` apunta a `v0.5.2` | Lo gestiona `maven-release-plugin` automáticamente |

---

## Archivos modificados

| Archivo | Tipo |
|---|---|
| `Dockerfile` | Modificado |
| `Dockerfile-db-postgresql` | Modificado |
| `docker-entrypoint.sh` | **Nuevo** |
| `scripts/podman-pod.sh` | Modificado |
| `scripts/publish-db-image.sh` | Modificado |
| `scripts/publish-images.sh` | Modificado |

---

## Testing

- Sintaxis bash verificada: `bash -n scripts/publish-images.sh` y `bash -n scripts/publish-db-image.sh` → OK
- `.dockerignore` revisado: `docker-entrypoint.sh` no está excluido del contexto de build
- `docker-compose.yml` y `podman-pod.sh` pasan `POSTGRES_PASSWORD` en runtime — compatibles con el `Dockerfile-db-postgresql` actualizado