### PR TITLE
docs: actualizar documentación Docker/Podman tras PR #131

### DIFF
--- a/docs/docker/DOCKER_IMAGES_GUIDE.md
+++ b/docs/docker/DOCKER_IMAGES_GUIDE.md
@@ -108,18 +108,18 @@ Esto genera `target/backend.jar` (~60MB)
 
 #### 2. Construir Imagen de PostgreSQL
 
+La imagen no embebe `POSTGRES_PASSWORD` — se pasa en runtime vía `docker-compose.yml` o `podman-pod.sh`.
+
 **Con Docker:**
 ```bash
-POSTGRES_PASSWORD=mi_password docker build -f Dockerfile-db-postgresql \
-    --build-arg POSTGRES_PASSWORD=mi_password \
+docker build -f Dockerfile-db-postgresql \
     -t isidromerayo/postgres-tfg:1.0 .
 docker tag isidromerayo/postgres-tfg:1.0 isidromerayo/postgres-tfg:latest
 ```
 
 **Con Podman:**
 ```bash
-POSTGRES_PASSWORD=mi_password podman build -f Dockerfile-db-postgresql \
-    --build-arg POSTGRES_PASSWORD=mi_password \
+podman build -f Dockerfile-db-postgresql \
     -t localhost/isidromerayo/postgres-tfg:1.0 .
 podman tag localhost/isidromerayo/postgres-tfg:1.0 localhost/isidromerayo/postgres-tfg:latest
 ```
@@ -168,26 +168,12 @@ Si construiste con Docker, el `docker-compose.yml` funcionará directamente:
 docker compose up -d
 ```
 
-Si construiste con Podman, actualiza `docker-compose.yml`:
-
-```yaml
-services:
-  maria_db:
-    image: "localhost/isidromerayo/mariadb-tfg:0.1.0"
-    # ...
-
-  api_service:
-    image: "localhost/isidromerayo/spring-backend-tfg:0.4.0"
-    # ...
-```
-
 #### Con Podman Pod
 
 Actualiza `scripts/podman-pod.sh`:
 
 ```bash
-MARIA_DB_IMAGE="localhost/isidromerayo/mariadb-tfg:0.1.0"
-API_SERVICE_IMAGE="localhost/isidromerayo/spring-backend-tfg:0.4.0"
+API_SERVICE_IMAGE="localhost/isidromerayo/spring-backend-tfg:0.6.2"
 ```
 
 Luego ejecuta:
@@ -225,8 +211,8 @@ El script:
 ### Publicar imagen de PostgreSQL
 
 ```bash
-# Requiere POSTGRES_PASSWORD como variable de entorno
-POSTGRES_PASSWORD=mi_password ./scripts/publish-db-image.sh 1.0
+# La imagen no embebe POSTGRES_PASSWORD — se pasa en runtime
+./scripts/publish-db-image.sh 1.0
 ```
 
 ### Publicación manual
@@ -239,9 +225,8 @@ docker build --build-arg VERSION=0.6.2 -t isidromerayo/spring-backend-tfg:0.6.2 
 docker push isidromerayo/spring-backend-tfg:0.6.2
 docker push isidromerayo/spring-backend-tfg:latest
 
-# PostgreSQL
+# PostgreSQL (POSTGRES_PASSWORD se pasa en runtime, no en el build)
 docker build -f Dockerfile-db-postgresql \
-    --build-arg POSTGRES_PASSWORD=mi_password \
     -t isidromerayo/postgres-tfg:1.0 .
 docker push isidromerayo/postgres-tfg:1.0
 docker push isidromerayo/postgres-tfg:latest
@@ -282,52 +267,14 @@ docker push isidromerayo/postgres-tfg:latest
 
 ## Verificación de Imágenes
 
-### Verificar Versión de MariaDB
-
-```bash
-# Inspeccionar imagen
-docker inspect isidromerayo/mariadb-tfg:0.1.0 | grep -A 5 "Env"
-
-# Ejecutar y verificar
-docker run --rm isidromerayo/mariadb-tfg:0.1.0 mariadbd --version
-```
-
 ### Verificar Versión del Backend
 
 ```bash
 # Inspeccionar imagen
-docker inspect isidromerayo/spring-backend-tfg:0.4.0 | grep -A 5 "Env"
+docker inspect isidromerayo/spring-backend-tfg:0.6.2 | grep -A 5 "Env"
 
 # Ejecutar y verificar logs
-docker run --rm isidromerayo/spring-backend-tfg:0.4.0 | head -20
-```
-
-### Verificar Contraseñas BCrypt
-
-```bash
-# Iniciar MariaDB
-docker run -d --name test-maria isidromerayo/mariadb-tfg:0.1.0
-
-# Esperar a que inicie
-sleep 10
-
-# Verificar contraseñas
-docker exec test-maria mariadb -u user_tfg -ptfg_un1r_PWD tfg_unir \
-  -e "SELECT id, nombre, LEFT(password, 30) FROM usuarios LIMIT 3"
-
-# Limpiar
-docker rm -f test-maria
-```
-
-Resultado esperado:
-```
-+----+---------------+--------------------------------+
-| id | nombre        | LEFT(password, 30)             |
-+----+---------------+--------------------------------+
-|  1 | María         | $2b$10$JKheLVrM5.jvtYVvd.tfqOL |
-|  2 | Juan Antonio  | $2b$10$JKheLVrM5.jvtYVvd.tfqOL |
-|  3 | Marta         | $2b$10$JKheLVrM5.jvtYVvd.tfqOL |
-+----+---------------+--------------------------------+
+docker run --rm isidromerayo/spring-backend-tfg:0.6.2 | head -20
 ```
 
 ---
@@ -343,7 +290,7 @@ Resultado esperado:
 ```bash
 # Construir localmente
 ./mvnw clean package -DskipTests
-docker build -f Dockerfile-db-postgresql --build-arg POSTGRES_PASSWORD=xxx -t isidromerayo/postgres-tfg:1.0 .
+docker build -f Dockerfile-db-postgresql -t isidromerayo/postgres-tfg:1.0 .
 docker build --build-arg VERSION=0.6.2 -t isidromerayo/spring-backend-tfg:0.6.2 .
 ```
 

--- a/docs/docker/DOCKER_WORKFLOW.md
+++ b/docs/docker/DOCKER_WORKFLOW.md
@@ -21,11 +21,11 @@ java -jar target/backend.jar
 
 ```bash
 # 1. Compilar el proyecto
-bash -c 'eval "$(vfox activate bash)" && vfox use -g java@21 && ./mvnw clean package -DskipTests'
+./mvnw clean package -DskipTests
 
 # 2. Construir la imagen con la nueva versión
-VERSION="0.2.2"  # Actualizar según corresponda
-podman build -t isidromerayo/spring-backend-tfg:${VERSION} .
+VERSION="0.6.2"  # Actualizar según corresponda
+podman build --build-arg VERSION=${VERSION} -t isidromerayo/spring-backend-tfg:${VERSION} .
 
 # 3. Crear tag latest (opcional, solo para versiones estables)
 podman tag isidromerayo/spring-backend-tfg:${VERSION} isidromerayo/spring-backend-tfg:latest
@@ -38,8 +38,8 @@ podman tag isidromerayo/spring-backend-tfg:${VERSION} isidromerayo/spring-backen
 ./mvnw clean package -DskipTests
 
 # 2. Construir la imagen
-VERSION="0.2.2"
-docker build -t isidromerayo/spring-backend-tfg:${VERSION} .
+VERSION="0.6.2"
+docker build --build-arg VERSION=${VERSION} -t isidromerayo/spring-backend-tfg:${VERSION} .
 
 # 3. Crear tag latest
 docker tag isidromerayo/spring-backend-tfg:${VERSION} isidromerayo/spring-backend-tfg:latest
@@ -78,7 +78,7 @@ curl -I -X OPTIONS http://localhost:8080/api/cursos \
 
 ```bash
 # 1. Actualizar docker-compose.yml con la nueva versión
-# Cambiar: image: "isidromerayo/spring-backend-tfg:0.2.2"
+# Cambiar: image: "isidromerayo/spring-backend-tfg:0.6.2"
 
 # 2. Levantar servicios
 docker compose up -d
@@ -92,9 +92,19 @@ docker compose down
 
 ### 4. Publicación en Docker Hub
 
-**⚠️ IMPORTANTE**: Solo publicar después de verificar que la imagen funciona correctamente localmente.
+**⚠️ IMPORTANTE**: Solo publicar después de verificar que la imagen funciona correctamente localmente. Usa los scripts en `scripts/` en lugar de comandos manuales — gestionan la detección Docker/Podman, validación SNAPSHOT y login automáticamente.
 
-#### Con Podman
+#### Con el script (recomendado)
+
+```bash
+# Verificar qué se publicaría
+./scripts/publish-images.sh --dry-run
+
+# Publicar
+./scripts/publish-images.sh
+```
+
+#### Con Podman (manual)
 
 ```bash
 # 1. Login en Docker Hub (solo la primera vez)
@@ -103,7 +113,7 @@ podman login docker.io
 # Password: [Personal Access Token]
 
 # 2. Push de la versión específica
-VERSION="0.2.2"
+VERSION="0.6.2"
 podman push isidromerayo/spring-backend-tfg:${VERSION}
 
 # 3. Push del tag latest (solo para versiones estables)
@@ -113,7 +123,7 @@ podman push isidromerayo/spring-backend-tfg:latest
 # https://hub.docker.com/r/isidromerayo/spring-backend-tfg/tags
 ```
 
-#### Con Docker
+#### Con Docker (manual)
 
 ```bash
 # 1. Login en Docker Hub
@@ -122,7 +132,7 @@ docker login
 # Password: [Personal Access Token]
 
 # 2. Push de la versión específica
-VERSION="0.2.2"
+VERSION="0.6.2"
 docker push isidromerayo/spring-backend-tfg:${VERSION}
 
 # 3. Push del tag latest
@@ -202,8 +212,8 @@ podman logs api_service
 # o
 docker logs api_service
 
-# Verificar que MariaDB está corriendo
-podman ps | grep maria_db
+# Verificar que PostgreSQL está corriendo
+podman ps | grep postgres_db
 ```
 
 ### Errores CORS en el frontend

--- a/docs/docker/PODMAN_GUIDE.md
+++ b/docs/docker/PODMAN_GUIDE.md
@@ -6,12 +6,12 @@ Podman es una alternativa a Docker que no requiere daemon y puede ejecutar conte
 
 ## Problema con podman-compose
 
-⚠️ **IMPORTANTE**: `podman-compose` tiene problemas conocidos con la resolución DNS entre contenedores. El backend no puede resolver el hostname `maria_db` correctamente.
+⚠️ **IMPORTANTE**: `podman-compose` tiene problemas conocidos con la resolución DNS entre contenedores. El backend no puede resolver el hostname `postgres_db` correctamente.
 
 **Error típico:**
 ```
-java.net.UnknownHostException: maria_db
-Socket fail to connect to maria_db
+java.net.UnknownHostException: postgres_db
+Socket fail to connect to postgres_db
 ```
 
 ## Solución: Usar Podman Pod
@@ -47,7 +47,7 @@ La solución recomendada es usar **Podman Pod** en lugar de `podman-compose`. Un
 ./scripts/podman-pod.sh logs
 ./scripts/podman-pod.sh logs api
 
-# Ver logs de MariaDB
+# Ver logs de PostgreSQL
 ./scripts/podman-pod.sh logs db
 ```
 
@@ -83,17 +83,17 @@ curl http://localhost:8080/api/categorias
 │         backend-pod                 │
 │                                     │
 │  ┌──────────────┐  ┌─────────────┐ │
-│  │   maria_db   │  │ api_service │ │
-│  │  (MariaDB)   │  │  (Spring)   │ │
+│  │  postgres_db │  │ api_service │ │
+│  │ (PostgreSQL) │  │  (Spring)   │ │
 │  │              │  │             │ │
 │  │ localhost:   │  │ localhost:  │ │
-│  │   3306       │  │   8080      │ │
+│  │   5432       │  │   8080      │ │
 │  └──────────────┘  └─────────────┘ │
 │                                     │
 │  Shared Network Namespace           │
 └─────────────────────────────────────┘
          │                    │
-    Port 3306            Port 8080
+    Port 5432            Port 8080
          │                    │
     Host Network
 ```
@@ -112,13 +112,13 @@ curl http://localhost:8080/api/categorias
 
 **Con podman-compose (NO FUNCIONA):**
 ```yaml
-SPRING_DATASOURCE_URL: jdbc:mariadb://maria_db:3306/tfg_unir
-# ❌ maria_db no se resuelve
+SPRING_DATASOURCE_URL: jdbc:postgresql://postgres_db:5432/tfg_unir
+# ❌ postgres_db no se resuelve
 ```
 
 **Con Podman Pod (FUNCIONA):**
 ```bash
-SPRING_DATASOURCE_URL: jdbc:mariadb://localhost:3306/tfg_unir
+SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5432/tfg_unir
 # ✅ localhost funciona porque comparten namespace
 ```
 
@@ -172,7 +172,7 @@ podman ps
 podman ps --pod --filter pod=backend-pod
 
 # Ejecutar comando en contenedor
-podman exec -it maria_db mariadb -u user_tfg -ptfg_un1r_PWD tfg_unir
+podman exec -it postgres_db psql -U user_tfg -d tfg_unir
 
 # Ver logs de un contenedor
 podman logs -f api_service
@@ -217,7 +217,7 @@ Error: cannot listen on the TCP port: address already in use
 ```bash
 # Ver qué está usando el puerto
 sudo lsof -i :8080
-sudo lsof -i :3306
+sudo lsof -i :5432
 
 # Detener el proceso o cambiar el puerto en el script
 ```
@@ -236,15 +236,15 @@ cd TFG_UNIR-backend
 ./scripts/podman-pod.sh start
 ```
 
-### Problema: MariaDB no inicia
+### Problema: PostgreSQL no inicia
 
 **Solución:**
 ```bash
-# Ver logs de MariaDB
+# Ver logs de PostgreSQL
 ./scripts/podman-pod.sh logs db
 
 # Eliminar volumen y reiniciar
-podman volume rm tfg_unir-backend_data
+podman volume rm tfg_unir-backend_pg_data
 ./scripts/podman-pod.sh start
 ```
 
@@ -252,8 +252,8 @@ podman volume rm tfg_unir-backend_data
 
 **Solución:**
 ```bash
-# Verificar que MariaDB está corriendo
-podman exec maria_db mariadb -u user_tfg -ptfg_un1r_PWD -e "SELECT 1"
+# Verificar que PostgreSQL está corriendo
+podman exec postgres_db pg_isready -U user_tfg -d tfg_unir
 
 # Ver logs del backend
 ./scripts/podman-pod.sh logs api
@@ -276,24 +276,13 @@ Si vienes de Docker, estos son los cambios principales:
 | `docker ps` | `podman ps` |
 | `docker exec` | `podman exec` |
 
-## Uso con BCrypt
-
-Para probar la migración a BCrypt con Podman:
+## Probar login
 
 ```bash
-# 1. Actualizar la versión de la imagen en el script
-# Editar scripts/podman-pod.sh:
-# MARIA_DB_IMAGE="isidromerayo/mariadb-tfg:0.0.5-bcrypt"
-
-# 2. Construir la imagen
-podman build -f Dockerfile-db -t isidromerayo/mariadb-tfg:0.0.5-bcrypt .
-
-# 3. Iniciar con la nueva imagen
-./scripts/podman-pod.sh start
-
-# 4. Probar login
+# Probar autenticación con usuarios de prueba
 ./scripts/test-login.sh
-```
+./scripts/test-login.sh helena@localhost 1234
+``````
 
 ## Referencias
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -48,29 +48,27 @@ Script para construir y publicar la imagen de PostgreSQL en Docker Hub.
 **Uso:**
 ```bash
 # Publicar con versión por defecto (1.0)
-POSTGRES_PASSWORD=<tu_password> ./scripts/publish-db-image.sh
+./scripts/publish-db-image.sh
 
 # Versión específica
-POSTGRES_PASSWORD=<tu_password> ./scripts/publish-db-image.sh 1.1
+./scripts/publish-db-image.sh 1.1
 
 # Solo mostrar qué haría
-POSTGRES_PASSWORD=<tu_password> ./scripts/publish-db-image.sh --dry-run
+./scripts/publish-db-image.sh --dry-run
 ```
 
-**Variables de entorno requeridas:**
+**Variables de entorno opcionales:**
 | Variable | Descripción | Default |
 |----------|-------------|---------|
-| `POSTGRES_PASSWORD` | Contraseña de PostgreSQL (**obligatoria**) | - |
 | `POSTGRES_DB` | Nombre de la base de datos | `tfg_unir` |
 | `POSTGRES_USER` | Usuario de PostgreSQL | `user_tfg` |
 
-**Qué hace:**
-1. Valida que `POSTGRES_PASSWORD` esté definido
-2. Construye la imagen de PostgreSQL con credenciales como `--build-arg`
-3. Etiqueta con `:version` y `:latest`
-4. Publica en Docker Hub
+> **Seguridad**: `POSTGRES_PASSWORD` **no** se embebe en la imagen para evitar que quede expuesta en el historial de capas (`docker history`). Se pasa en runtime vía `docker-compose.yml` o `podman-pod.sh`.
 
-> **⚠️ Seguridad**: Las credenciales **nunca** se hardcodean en el Dockerfile. Se pasan como variables de entorno y `--build-arg` en tiempo de build.
+**Qué hace:**
+1. Construye la imagen de PostgreSQL con `POSTGRES_DB` y `POSTGRES_USER` como `--build-arg`
+2. Etiqueta con `:version` y `:latest`
+3. Publica en Docker Hub
 
 #### `build-and-test-bcrypt.sh` *(DEPRECATED - legacy MariaDB)*
 Script legacy que verificaba BCrypt en MariaDB. Ya no es funcional tras la migración a PostgreSQL.
@@ -163,8 +161,8 @@ scripts/
 ### Publicar imagen de PostgreSQL
 
 ```bash
-# Requiere POSTGRES_PASSWORD como variable de entorno
-POSTGRES_PASSWORD=mi_password_secreto ./scripts/publish-db-image.sh 1.0
+# La imagen no embebe POSTGRES_PASSWORD (se pasa en runtime)
+./scripts/publish-db-image.sh 1.0
 ```
 
 ### Probar login
@@ -182,13 +180,6 @@ Para más información, consulta:
 - **Quick Start BCrypt**: `docs/security/QUICK_START_BCRYPT.md`
 
 ## Troubleshooting
-
-### publish-db-image.sh falla con "POSTGRES_PASSWORD no está definido"
-
-Define la variable de entorno antes de ejecutar:
-```bash
-POSTGRES_PASSWORD=tu_password ./scripts/publish-db-image.sh
-```
 
 ### publish-images.sh falla con "No se publican imágenes SNAPSHOT"
 


### PR DESCRIPTION
## Descripción

Actualización de la documentación Docker/Podman para reflejar los cambios introducidos en la PR #131 (`fix: corregir hallazgos análisis Docker/Podman`).

La PR #131 se mergeó antes de que el commit de documentación quedara incluido, por lo que se abre esta PR complementaria con únicamente los cambios de docs.

---

## Archivos modificados

| Archivo | Cambios |
|---|---|
| `docs/docker/DOCKER_IMAGES_GUIDE.md` | Eliminado `--build-arg POSTGRES_PASSWORD` de ejemplos de build; sección de imágenes locales limpia de referencias a MariaDB; troubleshooting actualizado |
| `docs/docker/DOCKER_WORKFLOW.md` | Versiones de ejemplo actualizadas a `0.6.2`; `maria_db` → `postgres_db` en troubleshooting; nueva sección de publicación con scripts recomendados |
| `docs/docker/PODMAN_GUIDE.md` | Diagrama actualizado (MariaDB/3306 → PostgreSQL/5432); comandos de contenedor corregidos (`postgres_db`, `psql`); sección «Uso con BCrypt» obsoleta eliminada |
| `scripts/README.md` | `publish-db-image.sh` ya no requiere `POSTGRES_PASSWORD` en build; `logs db` apunta a PostgreSQL; entrada de troubleshooting obsoleta eliminada |

---

## Detalle por archivo

### `docs/docker/DOCKER_IMAGES_GUIDE.md`

- **Build de PostgreSQL**: eliminado `--build-arg POSTGRES_PASSWORD` de todos los ejemplos. La imagen `postgres:17` lee `POSTGRES_PASSWORD` en runtime — no se embebe en las capas.
- **Imágenes locales con Podman**: eliminadas referencias a `mariadb-tfg` y a `maria_db`; actualizada sección «Con Podman Pod» con `API_SERVICE_IMAGE` actual.
- **Verificación de imágenes**: eliminado el bloque «Verificar Contraseñas BCrypt» con `mariadb-tfg:0.1.0` (imagen obsoleta).
- **Troubleshooting**: comando de build local de PostgreSQL sin `--build-arg POSTGRES_PASSWORD`.

### `docs/docker/DOCKER_WORKFLOW.md`

- **Construcción**: versiones de ejemplo actualizadas de `0.2.2` a `0.6.2`; añadido `--build-arg VERSION` que faltaba en ambas opciones.
- **Publicación**: nueva sección «Con el script (recomendado)» que apunta a `publish-images.sh`; versiones manuales actualizadas a `0.6.2`.
- **Troubleshooting**: `maria_db` → `postgres_db`.

### `docs/docker/PODMAN_GUIDE.md`

- **Diagrama ASCII**: `maria_db (MariaDB) :3306` → `postgres_db (PostgreSQL) :5432`.
- **Configuración de conexión**: ejemplos actualizados a `jdbc:postgresql://localhost:5432/`.
- **Comandos**: `podman exec maria_db mariadb ...` → `podman exec postgres_db psql ...`; `lsof :3306` → `lsof :5432`.
- **Troubleshooting BD**: «MariaDB no inicia» → «PostgreSQL no inicia»; `pg_isready` en lugar de consulta mariadb.
- **Sección obsoleta**: eliminado «Uso con BCrypt» que referenciaba `mariadb-tfg:0.0.5-bcrypt` y `Dockerfile-db`.

### `scripts/README.md`

- **`publish-db-image.sh`**: tabla de variables actualizada — `POSTGRES_PASSWORD` eliminada (ya no es `ARG` en el Dockerfile); nota de seguridad actualizada para reflejar que la contraseña se gestiona en runtime.
- **Quick Start PostgreSQL**: ejemplo sin `POSTGRES_PASSWORD` en el comando de build.
- **`podman-pod.sh` logs**: texto «Ver logs de MariaDB» → «Ver logs de PostgreSQL».
- **Troubleshooting**: eliminada la entrada `publish-db-image.sh falla con POSTGRES_PASSWORD no está definido` (ya no aplica).

---

## Relación con PR #131

Esta PR es la continuación documental de #131. Los cambios de código ya están en `main`; esta PR completa el ciclo actualizando todos los documentos de referencia para que sean coherentes con el estado actual del proyecto.

---

## Testing

No hay código ejecutable en esta PR — únicamente documentación Markdown. Revisión manual confirma que:
- Ninguna referencia a `MariaDB`, `mariadb-tfg`, `maria_db`, `3306` ni `--build-arg POSTGRES_PASSWORD` queda en los 4 archivos modificados.
- Los comandos de ejemplo son coherentes con los scripts y Dockerfiles actuales.