### PR TITLE
fix: migrate fb-contrib to sb-contrib and fix SonarQube workflow

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -37,7 +37,11 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       
-      - name: Build and analyze
+      - name: Build and test
+        run: mvn -B clean verify -Pintegration-tests
+
+      - name: SonarQube Analysis
+        if: env.SONAR_TOKEN != ''
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B clean verify -Pintegration-tests org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+        run: mvn -B org.sonarsource.scanner.maven:sonar-maven-plugin:sonar

--- a/pom.xml
+++ b/pom.xml
@@ -327,8 +327,8 @@
 							<version>1.14.0</version>
 						</plugin>
 						<plugin>
-							<groupId>com.mebigfatguy.fb-contrib</groupId>
-							<artifactId>fb-contrib</artifactId>
+							<groupId>com.mebigfatguy.sb-contrib</groupId>
+							<artifactId>sb-contrib</artifactId>
 							<version>7.7.4</version>
 						</plugin>
 					</plugins>


### PR DESCRIPTION
## Changes

- **fb-contrib → sb-contrib**: Migrated from FindBugs artifact (`com.mebigfatguy.fb-contrib:fb-contrib`) to SpotBugs-native artifact (`com.mebigfatguy.sb-contrib:sb-contrib:7.7.4`). Both are at latest version and compatible with SpotBugs 4.10.3.
- **SonarQube workflow fix**: Split the "Build and analyze" step so the build passes on Dependabot PRs where `SONAR_TOKEN` is unavailable. SonarQube analysis only runs when the token is present.

## Verification
- SpotBugs check: ✅ BUILD SUCCESS (0 errors/warnings)
- Unit tests: ✅ All passed